### PR TITLE
Swift 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_install: git submodule update --init --recursive
 
 # A custom test script is required because xctool cannot access the iOS keychain
 # https://github.com/facebook/xctool/issues/269
-script: xcodebuild -workspace $TRAVIS_XCODE_WORKSPACE -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK build test | xcpretty -c
+script: set -o pipefail && xcodebuild -workspace $TRAVIS_XCODE_WORKSPACE -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK build test | xcpretty -c

--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -34,9 +34,9 @@ public struct Generator: Equatable {
     - returns: A valid password generator, or `nil` if the parameters are invalid.
     */
     public init?(factor: Factor, secret: NSData, algorithm: Algorithm = defaultAlgorithm, digits: Int = defaultDigits) {
-        if !validateGenerator(factor: factor, secret: secret, algorithm: algorithm, digits: digits) {
-            return nil
-        }
+        guard validateGenerator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
+            else { return nil }
+
         self.factor = factor
         self.secret = secret
         self.algorithm = algorithm
@@ -99,7 +99,9 @@ public extension Generator {
     - returns: The current password, or `nil` if a password could not be generated.
     */
     var password: String? {
-        if !validateGenerator(factor: factor, secret: secret, algorithm: algorithm, digits: digits) { return nil }
+        guard validateGenerator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
+            else { return nil }
+
         let counter = counterForGeneratorWithFactor(factor, atTimeIntervalSince1970: NSDate().timeIntervalSince1970)
         return generatePassword(algorithm: algorithm, digits: digits, secret: secret, counter: counter)
     }

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -46,31 +46,29 @@ public func generatePassword(algorithm algorithm: Generator.Algorithm, digits: I
 
     // Generate an HMAC value from the key and counter
     let (hashAlgorithm, hashLength) = hashInfoForAlgorithm(algorithm)
-    if let hash = NSMutableData(length: hashLength) {
-        CCHmac(hashAlgorithm, secret.bytes, secret.length, &bigCounter, 8, hash.mutableBytes)
+    guard let hash = NSMutableData(length: hashLength)
+        else { return nil }
+    CCHmac(hashAlgorithm, secret.bytes, secret.length, &bigCounter, 8, hash.mutableBytes)
 
-        // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
-        let ptr = UnsafePointer<UInt8>(hash.bytes)
-        let offset = ptr[hash.length-1] & 0x0f
+    // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
+    let ptr = UnsafePointer<UInt8>(hash.bytes)
+    let offset = ptr[hash.length-1] & 0x0f
 
-        // Take 4 bytes from the hash, starting at the given byte offset
-        let truncatedHashPtr = ptr + Int(offset)
-        var truncatedHash = UnsafePointer<UInt32>(truncatedHashPtr).memory
+    // Take 4 bytes from the hash, starting at the given byte offset
+    let truncatedHashPtr = ptr + Int(offset)
+    var truncatedHash = UnsafePointer<UInt32>(truncatedHashPtr).memory
 
-        // Ensure the four bytes taken from the hash match the current endian format
-        truncatedHash = UInt32(bigEndian: truncatedHash)
-        // Discard the most significant bit
-        truncatedHash &= 0x7fffffff
-        // Constrain to the right number of digits
-        truncatedHash = truncatedHash % UInt32(pow(10, Float(digits)))
+    // Ensure the four bytes taken from the hash match the current endian format
+    truncatedHash = UInt32(bigEndian: truncatedHash)
+    // Discard the most significant bit
+    truncatedHash &= 0x7fffffff
+    // Constrain to the right number of digits
+    truncatedHash = truncatedHash % UInt32(pow(10, Float(digits)))
 
-        var string = String(truncatedHash)
-        // Pad the string representation with zeros, if necessary
-        while string.characters.count < digits {
-            string = "0" + string
-        }
-        return string
+    var string = String(truncatedHash)
+    // Pad the string representation with zeros, if necessary
+    while string.characters.count < digits {
+        string = "0" + string
     }
-
-    return nil
+    return string
 }

--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -23,10 +23,10 @@ func addKeychainItemWithAttributes(attributes: NSDictionary) -> NSData? {
         SecItemAdd(mutableAttributes, $0)
     }
 
-    if resultCode == OSStatus(errSecSuccess) {
-        return result as? NSData
-    }
-    return nil
+    guard resultCode == OSStatus(errSecSuccess)
+        else { return nil }
+
+    return result as? NSData
 }
 
 func updateKeychainItemForPersistentRef(persistentRef: NSData, withAttributes attributesToUpdate: NSDictionary) -> Bool {

--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -10,12 +10,12 @@ import Foundation
 
 func addKeychainItemWithAttributes(attributes: NSDictionary) -> NSData? {
     let mutableAttributes = attributes.mutableCopy() as! NSMutableDictionary
-    mutableAttributes[kSecClass as! NSCopying] = kSecClassGenericPassword
-    mutableAttributes[kSecReturnPersistentRef as! NSCopying] = kCFBooleanTrue
+    mutableAttributes[kSecClass as String] = kSecClassGenericPassword
+    mutableAttributes[kSecReturnPersistentRef as String] = kCFBooleanTrue
     // Set a random string for the account name.
     // We never query by or display this value, but the keychain requires it to be unique.
-    if (mutableAttributes[kSecAttrAccount as! NSCopying] == nil) {
-        mutableAttributes[kSecAttrAccount as! NSCopying] = NSUUID().UUIDString
+    if (mutableAttributes[kSecAttrAccount as String] == nil) {
+        mutableAttributes[kSecAttrAccount as String] = NSUUID().UUIDString
     }
 
     var result: AnyObject?
@@ -31,8 +31,8 @@ func addKeychainItemWithAttributes(attributes: NSDictionary) -> NSData? {
 
 func updateKeychainItemForPersistentRef(persistentRef: NSData, withAttributes attributesToUpdate: NSDictionary) -> Bool {
     let queryDict = [
-        kSecClass as! NSCopying: kSecClassGenericPassword,
-        kSecValuePersistentRef as! NSCopying: persistentRef,
+        kSecClass as String:               kSecClassGenericPassword,
+        kSecValuePersistentRef as String:  persistentRef,
     ]
 
     let resultCode = SecItemUpdate(queryDict, attributesToUpdate)
@@ -41,8 +41,8 @@ func updateKeychainItemForPersistentRef(persistentRef: NSData, withAttributes at
 
 func deleteKeychainItemForPersistentRef(persistentRef: NSData) -> Bool {
     let queryDict = [
-        kSecClass as! NSCopying: kSecClassGenericPassword,
-        kSecValuePersistentRef as! NSCopying: persistentRef,
+        kSecClass as String:               kSecClassGenericPassword,
+        kSecValuePersistentRef as String:  persistentRef,
     ]
 
     let resultCode = SecItemDelete(queryDict)

--- a/OneTimePassword/Token.URLSerializer.swift
+++ b/OneTimePassword/Token.URLSerializer.swift
@@ -115,10 +115,10 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
     }
 
     guard let factor = parse(url.host, with: factorParser, defaultTo: nil),
-        let secret = parse(queryDictionary[kQuerySecretKey], with: { MF_Base32Codec.dataFromBase32String($0) }, overrideWith: externalSecret),
-        let algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Generator.defaultAlgorithm),
-        let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Generator.defaultDigits),
-        let core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
+        secret = parse(queryDictionary[kQuerySecretKey], with: { MF_Base32Codec.dataFromBase32String($0) }, overrideWith: externalSecret),
+        algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Generator.defaultAlgorithm),
+        digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Generator.defaultDigits),
+        core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
         else { return nil }
 
     var name = Token.defaultName

--- a/OneTimePassword/Token.URLSerializer.swift
+++ b/OneTimePassword/Token.URLSerializer.swift
@@ -19,6 +19,7 @@ extension Token {
         public static func deserialize(string: String, secret: NSData? = nil) -> Token? {
             guard let url = NSURL(string: string)
                 else { return nil }
+            
             return tokenFromURL(url, secret: secret)
         }
     }
@@ -115,10 +116,10 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
     }
 
     guard let factor = parse(url.host, with: factorParser, defaultTo: nil),
-        secret = parse(queryDictionary[kQuerySecretKey], with: MF_Base32Codec.dataFromBase32String, overrideWith: externalSecret),
-        algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Generator.defaultAlgorithm),
-        digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Generator.defaultDigits),
-        core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
+        let secret = parse(queryDictionary[kQuerySecretKey], with: MF_Base32Codec.dataFromBase32String, overrideWith: externalSecret),
+        let algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Generator.defaultAlgorithm),
+        let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Generator.defaultDigits),
+        let core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
         else { return nil }
 
     var name = Token.defaultName
@@ -156,6 +157,7 @@ private func parse<P, T>(item: P?, with parser: (P -> T?), defaultTo defaultValu
     if let concrete = item {
         guard let value = parser(concrete)
             else { return nil }
+
         return value
     }
     return defaultValue

--- a/OneTimePassword/Token.URLSerializer.swift
+++ b/OneTimePassword/Token.URLSerializer.swift
@@ -17,10 +17,9 @@ extension Token {
         }
 
         public static func deserialize(string: String, secret: NSData? = nil) -> Token? {
-            if let url = NSURL(string: string) {
-                return tokenFromURL(url, secret: secret)
-            }
-            return nil
+            guard let url = NSURL(string: string)
+                else { return nil }
+            return tokenFromURL(url, secret: secret)
         }
     }
 }
@@ -82,13 +81,12 @@ private func urlForToken(name name: String, issuer: String, factor: Generator.Fa
 }
 
 private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> Token? {
-    if (url.scheme != kOTPAuthScheme) { return nil }
+    guard url.scheme == kOTPAuthScheme
+        else { return nil }
 
     var queryDictionary = Dictionary<String, String>()
-    if let queryItems = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)?.queryItems {
-        for item in queryItems {
-            queryDictionary[item.name] = item.value
-        }
+    NSURLComponents(URL: url, resolvingAgainstBaseURL: false)?.queryItems?.forEach { item in
+        queryDictionary[item.name] = item.value
     }
 
     let factorParser: (string: String) -> Generator.Factor? = { string in
@@ -96,20 +94,18 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
             if let counter: UInt64 = parse(queryDictionary[kQueryCounterKey], with: {
                 errno = 0
                 let counterValue = strtoull(($0 as NSString).UTF8String, nil, 10)
-                if errno == 0 {
-                    return counterValue
-                }
-                return nil
+                guard errno == 0
+                    else { return nil }
+                return counterValue
                 }, defaultTo: 0)
             {
                 return .Counter(counter)
             }
         } else if string == FactorTimerString {
             if let period: NSTimeInterval = parse(queryDictionary[kQueryPeriodKey], with: {
-                if let int = Int($0) {
-                    return NSTimeInterval(int)
-                }
-                return nil
+                guard let int = Int($0)
+                    else { return nil }
+                return NSTimeInterval(int)
                 }, defaultTo: 30)
             {
                 return .Timer(period: period)
@@ -118,43 +114,38 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
         return nil
     }
 
-    if let factor = parse(url.host, with: factorParser, defaultTo: nil) {
-        if let secret = parse(queryDictionary[kQuerySecretKey], with: { MF_Base32Codec.dataFromBase32String($0) }, overrideWith: externalSecret) {
-            if let algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Generator.defaultAlgorithm) {
-                if let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Generator.defaultDigits) {
-                    if let core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits) {
+    guard let factor = parse(url.host, with: factorParser, defaultTo: nil),
+        let secret = parse(queryDictionary[kQuerySecretKey], with: { MF_Base32Codec.dataFromBase32String($0) }, overrideWith: externalSecret),
+        let algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Generator.defaultAlgorithm),
+        let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Generator.defaultDigits),
+        let core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
+        else { return nil }
 
-                        var name = Token.defaultName
-                        if let path = url.path {
-                            if path.characters.count > 1 {
-                                name = path.substringFromIndex(path.startIndex.successor()) // Skip the leading "/"
-                            }
-                        }
-
-                        var issuer = Token.defaultIssuer
-                        if let issuerString = queryDictionary[kQueryIssuerKey] {
-                            issuer = issuerString
-                        } else {
-                            // If there is no issuer string, try to extract one from the name
-                            let components = name.componentsSeparatedByString(":")
-                            if components.count > 1 {
-                                issuer = components[0]
-                            }
-                        }
-                        // If the name is prefixed by the issuer string, trim the name
-                        if let prefixRange = name.rangeOfString(issuer) {
-                            if (prefixRange.startIndex == issuer.startIndex) && (issuer.characters.count < name.characters.count) && (name[prefixRange.endIndex] == ":") {
-                                name = name.substringFromIndex(prefixRange.endIndex.successor()).stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
-                            }
-                        }
-
-                        return Token(name: name, issuer: issuer, core: core)
-                    }
-                }
-            }
+    var name = Token.defaultName
+    if let path = url.path {
+        if path.characters.count > 1 {
+            name = path.substringFromIndex(path.startIndex.successor()) // Skip the leading "/"
         }
     }
-    return nil
+
+    var issuer = Token.defaultIssuer
+    if let issuerString = queryDictionary[kQueryIssuerKey] {
+        issuer = issuerString
+    } else {
+        // If there is no issuer string, try to extract one from the name
+        let components = name.componentsSeparatedByString(":")
+        if components.count > 1 {
+            issuer = components[0]
+        }
+    }
+    // If the name is prefixed by the issuer string, trim the name
+    if let prefixRange = name.rangeOfString(issuer) {
+        if (prefixRange.startIndex == issuer.startIndex) && (issuer.characters.count < name.characters.count) && (name[prefixRange.endIndex] == ":") {
+            name = name.substringFromIndex(prefixRange.endIndex.successor()).stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
+        }
+    }
+
+    return Token(name: name, issuer: issuer, core: core)
 }
 
 private func parse<P, T>(item: P?, with parser: (P -> T?), defaultTo defaultValue: T? = nil, overrideWith overrideValue: T? = nil) -> T? {
@@ -163,10 +154,9 @@ private func parse<P, T>(item: P?, with parser: (P -> T?), defaultTo defaultValu
     }
 
     if let concrete = item {
-        if let value = parser(concrete) {
-            return value
-        }
-        return nil
+        guard let value = parser(concrete)
+            else { return nil }
+        return value
     }
     return defaultValue
 }

--- a/OneTimePassword/Token.URLSerializer.swift
+++ b/OneTimePassword/Token.URLSerializer.swift
@@ -116,7 +116,7 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
     }
 
     guard let factor = parse(url.host, with: factorParser, defaultTo: nil),
-        let secret = parse(queryDictionary[kQuerySecretKey], with: MF_Base32Codec.dataFromBase32String, overrideWith: externalSecret),
+        let secret = parse(queryDictionary[kQuerySecretKey], with: { MF_Base32Codec.dataFromBase32String($0) }, overrideWith: externalSecret),
         let algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Generator.defaultAlgorithm),
         let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Generator.defaultDigits),
         let core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)

--- a/OneTimePassword/Token.URLSerializer.swift
+++ b/OneTimePassword/Token.URLSerializer.swift
@@ -115,7 +115,7 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
     }
 
     guard let factor = parse(url.host, with: factorParser, defaultTo: nil),
-        secret = parse(queryDictionary[kQuerySecretKey], with: { MF_Base32Codec.dataFromBase32String($0) }, overrideWith: externalSecret),
+        secret = parse(queryDictionary[kQuerySecretKey], with: MF_Base32Codec.dataFromBase32String, overrideWith: externalSecret),
         algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Generator.defaultAlgorithm),
         digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Generator.defaultDigits),
         core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)

--- a/OneTimePassword/Token.swift
+++ b/OneTimePassword/Token.swift
@@ -52,10 +52,9 @@ public func ==(lhs: Token, rhs: Token) -> Bool {
 public func updatedToken(token: Token) -> Token? {
     switch token.core.factor {
     case .Counter(let counter):
-        if let updatedGenerator = Generator(factor: .Counter(counter + 1), secret: token.core.secret, algorithm: token.core.algorithm, digits: token.core.digits) {
-            return Token(name: token.name, issuer: token.issuer, core: updatedGenerator)
-        }
-        return nil
+        guard let updatedGenerator = Generator(factor: .Counter(counter + 1), secret: token.core.secret, algorithm: token.core.algorithm, digits: token.core.digits)
+            else { return nil }
+        return Token(name: token.name, issuer: token.issuer, core: updatedGenerator)
     case .Timer:
         return token
     }

--- a/OneTimePassword/Token.swift
+++ b/OneTimePassword/Token.swift
@@ -54,6 +54,7 @@ public func updatedToken(token: Token) -> Token? {
     case .Counter(let counter):
         guard let updatedGenerator = Generator(factor: .Counter(counter + 1), secret: token.core.secret, algorithm: token.core.algorithm, digits: token.core.digits)
             else { return nil }
+        
         return Token(name: token.name, issuer: token.issuer, core: updatedGenerator)
     case .Timer:
         return token

--- a/OneTimePassword/TokenPersistence.swift
+++ b/OneTimePassword/TokenPersistence.swift
@@ -15,20 +15,25 @@ public extension Token {
         public let token: Token
         public let persistentRef: NSData
 
-        public static func keychainItemWithKeychainItemRef(keychainItemRef: NSData) -> KeychainItem? {
-            guard let result = keychainItemForPersistentRef(keychainItemRef)
-                else { return nil }
-            return keychainItemWithDictionary(result)
+        init(token: Token, persistentRef: NSData) {
+            self.token = token
+            self.persistentRef = persistentRef
         }
 
-        public static func keychainItemWithDictionary(keychainDictionary: NSDictionary) -> KeychainItem? {
+        public init?(keychainItemRef: NSData) {
+            guard let result = keychainItemForPersistentRef(keychainItemRef)
+                else { return nil }
+            self.init(keychainDictionary: result)
+        }
+
+        public init?(keychainDictionary: NSDictionary) {
             guard let urlData = keychainDictionary[kSecAttrGeneric as String] as? NSData,
                 let string = NSString(data: urlData, encoding:NSUTF8StringEncoding),
                 let secret = keychainDictionary[kSecValueData as String] as? NSData,
                 let keychainItemRef = keychainDictionary[kSecValuePersistentRef as String] as? NSData,
                 let token = Token.URLSerializer.deserialize(string as String, secret: secret)
                 else { return nil }
-            return KeychainItem(token: token, persistentRef: keychainItemRef)
+            self.init(token: token, persistentRef: keychainItemRef)
         }
 
         public static func allKeychainItems() -> Array<KeychainItem> {
@@ -38,7 +43,7 @@ public extension Token {
             var items = Array<KeychainItem>()
             for item: AnyObject in keychainItems {
                 if let keychainDict = item as? NSDictionary,
-                    let keychainItem = keychainItemWithDictionary(keychainDict) {
+                    let keychainItem = KeychainItem(keychainDictionary: keychainDict) {
                         items.append(keychainItem)
                 }
             }

--- a/OneTimePassword/TokenPersistence.swift
+++ b/OneTimePassword/TokenPersistence.swift
@@ -119,7 +119,8 @@ public func updateKeychainItem(keychainItem: Token.KeychainItem, withToken token
         kSecAttrGeneric as String:  data
     ]
 
-    guard updateKeychainItemForPersistentRef(keychainItem.persistentRef, withAttributes: attributes)
+    let success = updateKeychainItemForPersistentRef(keychainItem.persistentRef, withAttributes: attributes)
+    guard success
         else { return nil }
 
     return Token.KeychainItem(token: token, persistentRef: keychainItem.persistentRef)

--- a/OneTimePassword/TokenPersistence.swift
+++ b/OneTimePassword/TokenPersistence.swift
@@ -23,15 +23,16 @@ public extension Token {
         public init?(keychainItemRef: NSData) {
             guard let result = keychainItemForPersistentRef(keychainItemRef)
                 else { return nil }
+
             self.init(keychainDictionary: result)
         }
 
         public init?(keychainDictionary: NSDictionary) {
             guard let urlData = keychainDictionary[kSecAttrGeneric as String] as? NSData,
-                string = NSString(data: urlData, encoding:NSUTF8StringEncoding),
-                secret = keychainDictionary[kSecValueData as String] as? NSData,
-                keychainItemRef = keychainDictionary[kSecValuePersistentRef as String] as? NSData,
-                token = Token.URLSerializer.deserialize(string as String, secret: secret)
+                let string = NSString(data: urlData, encoding:NSUTF8StringEncoding),
+                let secret = keychainDictionary[kSecValueData as String] as? NSData,
+                let keychainItemRef = keychainDictionary[kSecValuePersistentRef as String] as? NSData,
+                let token = Token.URLSerializer.deserialize(string as String, secret: secret)
                 else { return nil }
 
             self.init(token: token, persistentRef: keychainItemRef)
@@ -44,7 +45,7 @@ public extension Token {
             var items = Array<KeychainItem>()
             for item: AnyObject in keychainItems {
                 if let keychainDict = item as? NSDictionary,
-                    keychainItem = KeychainItem(keychainDictionary: keychainDict) {
+                    let keychainItem = KeychainItem(keychainDictionary: keychainDict) {
                         items.append(keychainItem)
                 }
             }

--- a/OneTimePassword/TokenPersistence.swift
+++ b/OneTimePassword/TokenPersistence.swift
@@ -28,11 +28,12 @@ public extension Token {
 
         public init?(keychainDictionary: NSDictionary) {
             guard let urlData = keychainDictionary[kSecAttrGeneric as String] as? NSData,
-                let string = NSString(data: urlData, encoding:NSUTF8StringEncoding),
-                let secret = keychainDictionary[kSecValueData as String] as? NSData,
-                let keychainItemRef = keychainDictionary[kSecValuePersistentRef as String] as? NSData,
-                let token = Token.URLSerializer.deserialize(string as String, secret: secret)
+                string = NSString(data: urlData, encoding:NSUTF8StringEncoding),
+                secret = keychainDictionary[kSecValueData as String] as? NSData,
+                keychainItemRef = keychainDictionary[kSecValuePersistentRef as String] as? NSData,
+                token = Token.URLSerializer.deserialize(string as String, secret: secret)
                 else { return nil }
+
             self.init(token: token, persistentRef: keychainItemRef)
         }
 
@@ -43,7 +44,7 @@ public extension Token {
             var items = Array<KeychainItem>()
             for item: AnyObject in keychainItems {
                 if let keychainDict = item as? NSDictionary,
-                    let keychainItem = KeychainItem(keychainDictionary: keychainDict) {
+                    keychainItem = KeychainItem(keychainDictionary: keychainDict) {
                         items.append(keychainItem)
                 }
             }

--- a/OneTimePassword/TokenPersistence.swift
+++ b/OneTimePassword/TokenPersistence.swift
@@ -22,10 +22,10 @@ public extension Token {
         }
 
         public static func keychainItemWithDictionary(keychainDictionary: NSDictionary) -> KeychainItem? {
-            guard let urlData = keychainDictionary[kSecAttrGeneric as! NSCopying] as? NSData,
+            guard let urlData = keychainDictionary[kSecAttrGeneric as String] as? NSData,
                 let string = NSString(data: urlData, encoding:NSUTF8StringEncoding),
-                let secret = keychainDictionary[kSecValueData as! NSCopying] as? NSData,
-                let keychainItemRef = keychainDictionary[kSecValuePersistentRef as! NSCopying] as? NSData,
+                let secret = keychainDictionary[kSecValueData as String] as? NSData,
+                let keychainItemRef = keychainDictionary[kSecValuePersistentRef as String] as? NSData,
                 let token = Token.URLSerializer.deserialize(string as String, secret: secret)
                 else { return nil }
             return KeychainItem(token: token, persistentRef: keychainItemRef)
@@ -49,11 +49,11 @@ public extension Token {
 
 func keychainItemForPersistentRef(persistentRef: NSData) -> NSDictionary? {
     let queryDict = [
-        kSecClass as! NSCopying: kSecClassGenericPassword,
-        kSecValuePersistentRef as! NSCopying: persistentRef,
-        kSecReturnPersistentRef as! NSCopying: kCFBooleanTrue,
-        kSecReturnAttributes as! NSCopying: kCFBooleanTrue,
-        kSecReturnData as! NSCopying: kCFBooleanTrue,
+        kSecClass as String:                kSecClassGenericPassword,
+        kSecValuePersistentRef as String:   persistentRef,
+        kSecReturnPersistentRef as String:  kCFBooleanTrue,
+        kSecReturnAttributes as String:     kCFBooleanTrue,
+        kSecReturnData as String:           kCFBooleanTrue,
     ]
 
     var result: AnyObject?
@@ -69,11 +69,11 @@ func keychainItemForPersistentRef(persistentRef: NSData) -> NSDictionary? {
 
 func _allKeychainItems() -> NSArray? {
     let queryDict = [
-        kSecClass as! NSCopying: kSecClassGenericPassword,
-        kSecMatchLimit as! NSCopying: kSecMatchLimitAll,
-        kSecReturnPersistentRef as! NSCopying: kCFBooleanTrue,
-        kSecReturnAttributes as! NSCopying: kCFBooleanTrue,
-        kSecReturnData as! NSCopying: kCFBooleanTrue,
+        kSecClass as String:                kSecClassGenericPassword,
+        kSecMatchLimit as String:           kSecMatchLimitAll,
+        kSecReturnPersistentRef as String:  kCFBooleanTrue,
+        kSecReturnAttributes as String:     kCFBooleanTrue,
+        kSecReturnData as String:           kCFBooleanTrue,
     ]
 
     var result: AnyObject?
@@ -93,9 +93,9 @@ public func addTokenToKeychain(token: Token) -> Token.KeychainItem? {
         else { return nil }
 
     let attributes = [
-        kSecAttrGeneric as! NSCopying: data,
-        kSecValueData as! NSCopying: token.core.secret,
-        kSecAttrService as! NSCopying: kOTPService,
+        kSecAttrGeneric as String:  data,
+        kSecValueData as String:    token.core.secret,
+        kSecAttrService as String:  kOTPService,
     ]
 
     guard let persistentRef = addKeychainItemWithAttributes(attributes)
@@ -108,7 +108,9 @@ public func updateKeychainItem(keychainItem: Token.KeychainItem, withToken token
     guard let data = Token.URLSerializer.serialize(token)?.dataUsingEncoding(NSUTF8StringEncoding)
         else { return nil }
 
-    let attributes = [kSecAttrGeneric as! NSCopying: data]
+    let attributes = [
+        kSecAttrGeneric as String:  data
+    ]
 
     guard updateKeychainItemForPersistentRef(keychainItem.persistentRef, withAttributes: attributes)
         else { return nil }

--- a/OneTimePasswordLegacy/Conversion.swift
+++ b/OneTimePasswordLegacy/Conversion.swift
@@ -21,10 +21,10 @@ internal extension OTPAlgorithm {
 
 
 internal func tokenForOTPToken(token: OTPToken) -> Token? {
-    if let generator = generatorForOTPToken(token) {
-        return Token(name: token.name, issuer: token.issuer, core: generator)
-    }
-    return nil
+    guard let generator = generatorForOTPToken(token)
+        else { return nil }
+
+    return Token(name: token.name, issuer: token.issuer, core: generator)
 }
 
 private func generatorForOTPToken(token: OTPToken) -> Generator? {

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -163,7 +163,7 @@ public extension OTPToken {
     }
 
     static func tokenWithKeychainItemRef(keychainItemRef: NSData) -> Self? {
-        guard let keychainItem = Token.KeychainItem.keychainItemWithKeychainItemRef(keychainItemRef)
+        guard let keychainItem = Token.KeychainItem(keychainItemRef: keychainItemRef)
             else { return nil }
 
         return self.tokenWithKeychainItem(keychainItem)
@@ -171,7 +171,7 @@ public extension OTPToken {
 
     // This should be private, but is public for testing purposes
     static func tokenWithKeychainDictionary(keychainDictionary: NSDictionary) -> Self? {
-        guard let keychainItem = Token.KeychainItem.keychainItemWithDictionary(keychainDictionary)
+        guard let keychainItem = Token.KeychainItem(keychainDictionary: keychainDictionary)
             else { return nil }
 
         return self.tokenWithKeychainItem(keychainItem)

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -78,19 +78,17 @@ public extension OTPToken {
     }
 
     func updatePassword() {
-        if let token = token {
-            if let newToken = updatedToken(token) {
-                updateWithToken(newToken)
-            }
+        if let token = token, newToken = updatedToken(token) {
+            updateWithToken(newToken)
         }
     }
 
     // This should be private, but is public for testing purposes
     func generatePasswordForCounter(counter: UInt64) -> String? {
-        if let token = token {
-            return generatePassword(algorithm: token.core.algorithm, digits: token.core.digits, secret: token.core.secret, counter: counter)
-        }
-        return nil
+        guard let token = token
+            else { return nil }
+
+        return generatePassword(algorithm: token.core.algorithm, digits: token.core.digits, secret: token.core.secret, counter: counter)
     }
 }
 
@@ -100,21 +98,20 @@ public extension OTPToken {
     }
 
     static func tokenWithURL(url: NSURL, secret: NSData?) -> Self? {
-        if let token = Token.URLSerializer.deserialize(url.absoluteString, secret: secret) {
-            let otp = self.init()
-            otp.updateWithToken(token)
-            return otp
-        }
-        return nil
+        guard let token = Token.URLSerializer.deserialize(url.absoluteString, secret: secret)
+            else { return nil }
+
+        let otp = self.init()
+        otp.updateWithToken(token)
+        return otp
     }
 
     func url() -> NSURL? {
-        if let token = token {
-            if let string = Token.URLSerializer.serialize(token) {
-                return NSURL(string: string)
-            }
-        }
-        return nil
+        guard let token = token,
+            let string = Token.URLSerializer.serialize(token)
+            else { return nil }
+
+        return NSURL(string: string)
     }
 }
 
@@ -123,32 +120,34 @@ public extension OTPToken {
     var isInKeychain: Bool { return (keychainItemRef != nil) }
 
     func saveToKeychain() -> Bool {
-        if let token = token {
-            if let keychainItem = self.keychainItem {
-                if let newKeychainItem = updateKeychainItem(keychainItem, withToken: token) {
-                    self.keychainItem = newKeychainItem
-                    return true
-                }
-                return false
-            } else {
-                if let newKeychainItem = addTokenToKeychain(token) {
-                    self.keychainItem = newKeychainItem
-                    return true
-                }
-                return false
-            }
+        guard let token = token
+            else { return false }
+
+        if let keychainItem = self.keychainItem {
+            guard let newKeychainItem = updateKeychainItem(keychainItem, withToken: token)
+                else { return false }
+
+            self.keychainItem = newKeychainItem
+            return true
+        } else {
+            guard let newKeychainItem = addTokenToKeychain(token)
+                else { return false }
+
+            self.keychainItem = newKeychainItem
+            return true
         }
-        return false
     }
 
     func removeFromKeychain() -> Bool {
-        if let keychainItem = self.keychainItem {
-            if deleteKeychainItem(keychainItem) {
-                self.keychainItem = nil
-                return true
-            }
+        guard let keychainItem = self.keychainItem
+            else { return false }
+
+        if deleteKeychainItem(keychainItem) {
+            self.keychainItem = nil
+            return true
+        } else {
+            return false
         }
-        return false
     }
 
     static func allTokensInKeychain() -> Array<OTPToken> {
@@ -164,17 +163,17 @@ public extension OTPToken {
     }
 
     static func tokenWithKeychainItemRef(keychainItemRef: NSData) -> Self? {
-        if let keychainItem = Token.KeychainItem.keychainItemWithKeychainItemRef(keychainItemRef) {
-            return self.tokenWithKeychainItem(keychainItem)
-        }
-        return nil
+        guard let keychainItem = Token.KeychainItem.keychainItemWithKeychainItemRef(keychainItemRef)
+            else { return nil }
+
+        return self.tokenWithKeychainItem(keychainItem)
     }
 
     // This should be private, but is public for testing purposes
     static func tokenWithKeychainDictionary(keychainDictionary: NSDictionary) -> Self? {
-        if let keychainItem = Token.KeychainItem.keychainItemWithDictionary(keychainDictionary) {
-            return self.tokenWithKeychainItem(keychainItem)
-        }
-        return nil
+        guard let keychainItem = Token.KeychainItem.keychainItemWithDictionary(keychainDictionary)
+            else { return nil }
+
+        return self.tokenWithKeychainItem(keychainItem)
     }
 }

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -108,7 +108,7 @@ public extension OTPToken {
 
     func url() -> NSURL? {
         guard let token = token,
-            let string = Token.URLSerializer.serialize(token)
+            string = Token.URLSerializer.serialize(token)
             else { return nil }
 
         return NSURL(string: string)

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -143,12 +143,11 @@ public extension OTPToken {
         guard let keychainItem = self.keychainItem
             else { return false }
 
-        if deleteKeychainItem(keychainItem) {
+        let success = deleteKeychainItem(keychainItem)
+        if success {
             self.keychainItem = nil
-            return true
-        } else {
-            return false
         }
+        return success
     }
 
     static func allTokensInKeychain() -> Array<OTPToken> {

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -78,8 +78,9 @@ public extension OTPToken {
     }
 
     func updatePassword() {
-        if let token = token, newToken = updatedToken(token) {
-            updateWithToken(newToken)
+        if let token = token,
+            let newToken = updatedToken(token) {
+                updateWithToken(newToken)
         }
     }
 
@@ -108,7 +109,7 @@ public extension OTPToken {
 
     func url() -> NSURL? {
         guard let token = token,
-            string = Token.URLSerializer.serialize(token)
+            let string = Token.URLSerializer.serialize(token)
             else { return nil }
 
         return NSURL(string: string)


### PR DESCRIPTION
Refactor to use Swift 2 syntax:
 - Clean up nested `if` statements with `guard` statements and `if let` chaining
 - Remove force casting by bridging keychain query keys to `String`s
 - Convert `KeychainItem` constructor methods into failable initializers

Also, fix test failure reporting from Travis.