### PR TITLE
CommonCrypto wrapper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "Carthage/Checkouts/xcconfigs"]
 	path = Carthage/Checkouts/xcconfigs
 	url = https://github.com/jspahrsummers/xcconfigs.git
+[submodule "Carthage/Checkouts/Crypto"]
+	path = Carthage/Checkouts/Crypto
+	url = https://github.com/soffes/Crypto.git

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
 github "mattrubin/Base32" "master"
 github "jspahrsummers/xcconfigs"
+github "soffes/Crypto"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
+github "soffes/Crypto" "v0.1.0"
 github "jspahrsummers/xcconfigs" "0.8.1"
 github "mattrubin/Base32" "2fd38e9b9f7f9dadf08192b912bf13e50faf23d8"

--- a/OneTimePassword.xcodeproj/project.pbxproj
+++ b/OneTimePassword.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		C9DC7EC4196BD5DF00B50C82 /* Token.URLSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DC7EC3196BD5DF00B50C82 /* Token.URLSerializer.swift */; };
 		C9DC7EC8196BDF3B00B50C82 /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DC7EC7196BDF3B00B50C82 /* Generator.swift */; };
 		C9E639081BDDFCA0002D9231 /* CommonCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9E639071BDDFCA0002D9231 /* CommonCrypto.framework */; };
+		C9E639091BDDFF6B002D9231 /* OneTimePassword.h in Headers */ = {isa = PBXBuildFile; fileRef = C9377D40196B93F900D6C67E /* OneTimePassword.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C9F5981B196E3E48002E4D0E /* TokenPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F5981A196E3E48002E4D0E /* TokenPersistence.swift */; };
 /* End PBXBuildFile section */
 
@@ -70,7 +71,7 @@
 		C9003417196F7046009733E8 /* Keychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		C9290C2F1947D104008AE4DE /* TokenSerializationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenSerializationTests.swift; sourceTree = "<group>"; };
 		C9307A8419A8515300609B02 /* TokenSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenSerializer.swift; sourceTree = "<group>"; };
-		C9377D40196B93F900D6C67E /* OneTimePassword-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OneTimePassword-Bridging-Header.h"; sourceTree = "<group>"; };
+		C9377D40196B93F900D6C67E /* OneTimePassword.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneTimePassword.h; sourceTree = "<group>"; };
 		C93A24FC196AF8E900F86892 /* OTPTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTPTypes.h; sourceTree = "<group>"; };
 		C93A2513196AFE1100F86892 /* OTPTokenGenerationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTPTokenGenerationTests.m; sourceTree = "<group>"; };
 		C93A2514196AFE1100F86892 /* OTPTokenPersistenceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTPTokenPersistenceTests.m; sourceTree = "<group>"; };
@@ -224,7 +225,7 @@
 			isa = PBXGroup;
 			children = (
 				C97C823C1946E51D00FD9F4C /* Info.plist */,
-				C9377D40196B93F900D6C67E /* OneTimePassword-Bridging-Header.h */,
+				C9377D40196B93F900D6C67E /* OneTimePassword.h */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -371,6 +372,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C9E639091BDDFF6B002D9231 /* OneTimePassword.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -663,7 +665,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.mattrubin.onetimepassword;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "OneTimePassword/OneTimePassword-Bridging-Header.h";
 			};
 			name = Debug;
 		};
@@ -679,7 +680,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.mattrubin.onetimepassword;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "OneTimePassword/OneTimePassword-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/OneTimePassword.xcodeproj/project.pbxproj
+++ b/OneTimePassword.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		C9B2A19C199A7F1B00BC4A8A /* EquatableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B2A19B199A7F1B00BC4A8A /* EquatableTests.swift */; };
 		C9DC7EC4196BD5DF00B50C82 /* Token.URLSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DC7EC3196BD5DF00B50C82 /* Token.URLSerializer.swift */; };
 		C9DC7EC8196BDF3B00B50C82 /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DC7EC7196BDF3B00B50C82 /* Generator.swift */; };
+		C9E639081BDDFCA0002D9231 /* CommonCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9E639071BDDFCA0002D9231 /* CommonCrypto.framework */; };
 		C9F5981B196E3E48002E4D0E /* TokenPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F5981A196E3E48002E4D0E /* TokenPersistence.swift */; };
 /* End PBXBuildFile section */
 
@@ -114,6 +115,7 @@
 		C9DC7EC3196BD5DF00B50C82 /* Token.URLSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Token.URLSerializer.swift; sourceTree = "<group>"; };
 		C9DC7EC7196BDF3B00B50C82 /* Generator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Generator.swift; sourceTree = "<group>"; };
 		C9DC7ECC196C4D3D00B50C82 /* OTPToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTPToken.swift; sourceTree = "<group>"; };
+		C9E639071BDDFCA0002D9231 /* CommonCrypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CommonCrypto.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9F5981A196E3E48002E4D0E /* TokenPersistence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenPersistence.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -123,6 +125,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C944A55F1A7EDAE200E08B1E /* Base32.framework in Frameworks */,
+				C9E639081BDDFCA0002D9231 /* CommonCrypto.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -156,6 +159,7 @@
 			isa = PBXGroup;
 			children = (
 				C944A55E1A7EDAE200E08B1E /* Base32.framework */,
+				C9E639071BDDFCA0002D9231 /* CommonCrypto.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/OneTimePassword.xcworkspace/contents.xcworkspacedata
+++ b/OneTimePassword.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "group:Carthage/Checkouts/Base32/Base32.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Carthage/Checkouts/Crypto/Crypto.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CommonCrypto
 
 internal func validateGenerator(factor factor: Generator.Factor, secret: NSData, algorithm: Generator.Algorithm, digits: Int) -> Bool {
     let validDigits: (Int) -> Bool = { (6 <= $0) && ($0 <= 8) }

--- a/OneTimePassword/OneTimePassword-Bridging-Header.h
+++ b/OneTimePassword/OneTimePassword-Bridging-Header.h
@@ -5,5 +5,3 @@
 //  Created by Matt Rubin on 7/7/14.
 //  Copyright (c) 2014 Matt Rubin. All rights reserved.
 //
-
-#import <CommonCrypto/CommonHMAC.h>

--- a/OneTimePassword/OneTimePassword.h
+++ b/OneTimePassword/OneTimePassword.h
@@ -1,5 +1,5 @@
 //
-//  OneTimePassword-Bridging-Header.h
+//  OneTimePassword.h
 //  OneTimePassword
 //
 //  Created by Matt Rubin on 7/7/14.


### PR DESCRIPTION
 - Add an umbrella header (to quiet Xcode's warning)
 - Remove the umbrella header (which isn't allowed in frameworks)
 - Add a framework wrapper for CommonCrypto (so it can be accessed from Swift).