### PR TITLE
Generator Error Handling

### DIFF
--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -87,7 +87,12 @@ public func ==(lhs: Generator.Factor, rhs: Generator.Factor) -> Bool {
 
 public extension Generator {
     var isValid: Bool {
-        return validateGenerator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
+        switch factor {
+        case .Counter:
+            return validateDigits(digits)
+        case .Timer(let period):
+            return validateDigits(digits) && validatePeriod(period)
+        }
     }
 
     /**
@@ -100,9 +105,6 @@ public extension Generator {
     - returns: The current password, or `nil` if a password could not be generated.
     */
     var password: String? {
-        guard validateGenerator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
-            else { return nil }
-
         do {
             let counter = try counterForGeneratorWithFactor(factor, atTimeIntervalSince1970: NSDate().timeIntervalSince1970)
             let password = try generatePassword(algorithm: algorithm, digits: digits, secret: secret, counter: counter)

--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -86,12 +86,15 @@ public func ==(lhs: Generator.Factor, rhs: Generator.Factor) -> Bool {
 }
 
 public extension Generator {
-    var isValid: Bool {
+    var _isValid: Bool {
+        let validDigits: (Int) -> Bool = { (6 <= $0) && ($0 <= 8) }
+        let validPeriod: (NSTimeInterval) -> Bool = { (0 < $0) && ($0 <= 300) }
+
         switch factor {
         case .Counter:
-            return validateDigits(digits)
+            return validDigits(digits)
         case .Timer(let period):
-            return validateDigits(digits) && validatePeriod(period)
+            return validDigits(digits) && validPeriod(period)
         }
     }
 

--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -86,18 +86,6 @@ public func ==(lhs: Generator.Factor, rhs: Generator.Factor) -> Bool {
 }
 
 public extension Generator {
-    var _isValid: Bool {
-        let validDigits: (Int) -> Bool = { (6 <= $0) && ($0 <= 8) }
-        let validPeriod: (NSTimeInterval) -> Bool = { (0 < $0) && ($0 <= 300) }
-
-        switch factor {
-        case .Counter:
-            return validDigits(digits)
-        case .Timer(let period):
-            return validDigits(digits) && validPeriod(period)
-        }
-    }
-
     /**
     Calculates the current password based on the generator's configuration. The password generated
     will be consistent for a counter-based generator, but for a timer-based generator the password

--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -105,7 +105,8 @@ public extension Generator {
 
         do {
             let counter = try counterForGeneratorWithFactor(factor, atTimeIntervalSince1970: NSDate().timeIntervalSince1970)
-            return generatePassword(algorithm: algorithm, digits: digits, secret: secret, counter: counter)
+            let password = try generatePassword(algorithm: algorithm, digits: digits, secret: secret, counter: counter)
+            return password
         } catch {
             return nil
         }

--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -103,7 +103,11 @@ public extension Generator {
         guard validateGenerator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
             else { return nil }
 
-        let counter = counterForGeneratorWithFactor(factor, atTimeIntervalSince1970: NSDate().timeIntervalSince1970)
-        return generatePassword(algorithm: algorithm, digits: digits, secret: secret, counter: counter)
+        do {
+            let counter = try counterForGeneratorWithFactor(factor, atTimeIntervalSince1970: NSDate().timeIntervalSince1970)
+            return generatePassword(algorithm: algorithm, digits: digits, secret: secret, counter: counter)
+        } catch {
+            return nil
+        }
     }
 }

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -24,6 +24,7 @@ internal func validateGenerator(factor factor: Generator.Factor, secret: NSData,
 enum GenerationError: ErrorType {
     case InvalidTime
     case InvalidPeriod
+    case InvalidDigits
 }
 
 public func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeIntervalSince1970 timeInterval: NSTimeInterval) throws -> UInt64 {
@@ -39,7 +40,13 @@ public func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeInterv
     }
 }
 
-public func generatePassword(algorithm algorithm: Generator.Algorithm, digits: Int, secret: NSData, counter: UInt64) -> String {
+private let minimumDigits = 1 // Zero or negative digits makes no sense
+private let maximumDigits = 9 // 10 digits overflows UInt32.max
+
+public func generatePassword(algorithm algorithm: Generator.Algorithm, digits: Int, secret: NSData, counter: UInt64) throws -> String {
+    guard (minimumDigits...maximumDigits).contains(digits)
+        else { throw GenerationError.InvalidDigits }
+    
     func hashInfoForAlgorithm(algorithm: Generator.Algorithm) -> (algorithm: CCHmacAlgorithm, length: Int) {
         switch algorithm {
         case .SHA1:

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -16,14 +16,16 @@ private func validateDigits(digits: Int) -> Bool {
     return (minimumDigits...maximumDigits).contains(digits)
 }
 
-internal func validateGenerator(factor factor: Generator.Factor, secret: NSData, algorithm: Generator.Algorithm, digits: Int) -> Bool {
-    let validPeriod: (NSTimeInterval) -> Bool = { (0 < $0) && ($0 <= 300) }
+private func validatePeriod(period: NSTimeInterval) -> Bool {
+    return (period > 0)
+}
 
+internal func validateGenerator(factor factor: Generator.Factor, secret: NSData, algorithm: Generator.Algorithm, digits: Int) -> Bool {
     switch factor {
     case .Counter:
         return validateDigits(digits)
     case .Timer(let period):
-        return validateDigits(digits) && validPeriod(period)
+        return validateDigits(digits) && validatePeriod(period)
     }
 }
 
@@ -40,7 +42,7 @@ public func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeInterv
     case .Timer(let period):
         guard timeInterval >= 0
             else { throw GenerationError.InvalidTime }
-        guard period > 0
+        guard validatePeriod(period)
             else { throw GenerationError.InvalidPeriod }
         return UInt64(timeInterval / period)
     }

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -30,7 +30,7 @@ public func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeInterv
     }
 }
 
-public func generatePassword(algorithm algorithm: Generator.Algorithm, digits: Int, secret: NSData, counter: UInt64) -> String? {
+public func generatePassword(algorithm algorithm: Generator.Algorithm, digits: Int, secret: NSData, counter: UInt64) -> String {
     func hashInfoForAlgorithm(algorithm: Generator.Algorithm) -> (algorithm: CCHmacAlgorithm, length: Int) {
         switch algorithm {
         case .SHA1:

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -17,11 +17,6 @@ private func validateDigits(digits: Int) -> Bool {
     return (minimumDigits...maximumDigits).contains(digits)
 }
 
-/// Checks the given time period to ensure the value can be safely used to generate a password.
-private func validatePeriod(period: NSTimeInterval) -> Bool {
-    return (period > 0)
-}
-
 /// Checks the given epoch time to ensure the value can be safely used to generate a password.
 private func validateTime(time: NSTimeInterval) -> Bool {
     return (time >= 0)
@@ -40,12 +35,11 @@ public func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeInterv
     case .Timer(let period):
         guard validateTime(timeInterval)
             else { throw GenerationError.InvalidTime }
-        guard validatePeriod(period)
+        guard (period > 0)
             else { throw GenerationError.InvalidPeriod }
         return UInt64(timeInterval / period)
     }
 }
-
 
 public func generatePassword(algorithm algorithm: Generator.Algorithm, digits: Int, secret: NSData, counter: UInt64) throws -> String {
     guard validateDigits(digits)

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -20,6 +20,10 @@ internal func validatePeriod(period: NSTimeInterval) -> Bool {
     return (period > 0)
 }
 
+internal func validateTime(time: NSTimeInterval) -> Bool {
+    return (time >= 0)
+}
+
 enum GenerationError: ErrorType {
     case InvalidTime
     case InvalidPeriod
@@ -31,7 +35,7 @@ public func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeInterv
     case .Counter(let counter):
         return counter
     case .Timer(let period):
-        guard timeInterval >= 0
+        guard validateTime(timeInterval)
             else { throw GenerationError.InvalidTime }
         guard validatePeriod(period)
             else { throw GenerationError.InvalidPeriod }

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -17,11 +17,6 @@ private func validateDigits(digits: Int) -> Bool {
     return (minimumDigits...maximumDigits).contains(digits)
 }
 
-/// Checks the given epoch time to ensure the value can be safely used to generate a password.
-private func validateTime(time: NSTimeInterval) -> Bool {
-    return (time >= 0)
-}
-
 enum GenerationError: ErrorType {
     case InvalidTime
     case InvalidPeriod
@@ -33,8 +28,10 @@ public func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeInterv
     case .Counter(let counter):
         return counter
     case .Timer(let period):
-        guard validateTime(timeInterval)
+        // The time interval must be positive to produce a valid counter value.
+        guard (timeInterval >= 0)
             else { throw GenerationError.InvalidTime }
+        // The period must be positive and non-zero to produce a valid counter value.
         guard (period > 0)
             else { throw GenerationError.InvalidPeriod }
         return UInt64(timeInterval / period)

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -9,14 +9,6 @@
 import Foundation
 import CommonCrypto
 
-let minimumDigits = 1 // Zero or negative digits makes no sense
-let maximumDigits = 9 // 10 digits overflows UInt32.max
-
-/// Checks the given number of digits to ensure the value can be safely used to generate a password.
-private func validateDigits(digits: Int) -> Bool {
-    return (minimumDigits...maximumDigits).contains(digits)
-}
-
 enum GenerationError: ErrorType {
     case InvalidTime
     case InvalidPeriod
@@ -39,7 +31,9 @@ public func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeInterv
 }
 
 public func generatePassword(algorithm algorithm: Generator.Algorithm, digits: Int, secret: NSData, counter: UInt64) throws -> String {
-    guard validateDigits(digits)
+    let minimumDigits = 1 // Zero or negative digits makes no sense
+    let maximumDigits = 9 // 10 digits overflows UInt32.max
+    guard (minimumDigits...maximumDigits).contains(digits)
         else { throw GenerationError.InvalidDigits }
 
     func hashInfoForAlgorithm(algorithm: Generator.Algorithm) -> (algorithm: CCHmacAlgorithm, length: Int) {

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -12,21 +12,12 @@ import CommonCrypto
 let minimumDigits = 1 // Zero or negative digits makes no sense
 let maximumDigits = 9 // 10 digits overflows UInt32.max
 
-private func validateDigits(digits: Int) -> Bool {
+internal func validateDigits(digits: Int) -> Bool {
     return (minimumDigits...maximumDigits).contains(digits)
 }
 
-private func validatePeriod(period: NSTimeInterval) -> Bool {
+internal func validatePeriod(period: NSTimeInterval) -> Bool {
     return (period > 0)
-}
-
-internal func validateGenerator(factor factor: Generator.Factor, secret: NSData, algorithm: Generator.Algorithm, digits: Int) -> Bool {
-    switch factor {
-    case .Counter:
-        return validateDigits(digits)
-    case .Timer(let period):
-        return validateDigits(digits) && validatePeriod(period)
-    }
 }
 
 enum GenerationError: ErrorType {

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -12,15 +12,15 @@ import CommonCrypto
 let minimumDigits = 1 // Zero or negative digits makes no sense
 let maximumDigits = 9 // 10 digits overflows UInt32.max
 
-internal func validateDigits(digits: Int) -> Bool {
+private func validateDigits(digits: Int) -> Bool {
     return (minimumDigits...maximumDigits).contains(digits)
 }
 
-internal func validatePeriod(period: NSTimeInterval) -> Bool {
+private func validatePeriod(period: NSTimeInterval) -> Bool {
     return (period > 0)
 }
 
-internal func validateTime(time: NSTimeInterval) -> Bool {
+private func validateTime(time: NSTimeInterval) -> Bool {
     return (time >= 0)
 }
 

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -21,11 +21,20 @@ internal func validateGenerator(factor factor: Generator.Factor, secret: NSData,
     }
 }
 
-public func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeIntervalSince1970 timeInterval: NSTimeInterval) -> UInt64 {
+enum GenerationError: ErrorType {
+    case InvalidTime
+    case InvalidPeriod
+}
+
+public func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeIntervalSince1970 timeInterval: NSTimeInterval) throws -> UInt64 {
     switch factor {
     case .Counter(let counter):
         return counter
     case .Timer(let period):
+        guard timeInterval >= 0
+            else { throw GenerationError.InvalidTime }
+        guard period > 0
+            else { throw GenerationError.InvalidPeriod }
         return UInt64(timeInterval / period)
     }
 }

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -12,14 +12,17 @@ import CommonCrypto
 let minimumDigits = 1 // Zero or negative digits makes no sense
 let maximumDigits = 9 // 10 digits overflows UInt32.max
 
+/// Checks the given number of digits to ensure the value can be safely used to generate a password.
 private func validateDigits(digits: Int) -> Bool {
     return (minimumDigits...maximumDigits).contains(digits)
 }
 
+/// Checks the given time period to ensure the value can be safely used to generate a password.
 private func validatePeriod(period: NSTimeInterval) -> Bool {
     return (period > 0)
 }
 
+/// Checks the given epoch time to ensure the value can be safely used to generate a password.
 private func validateTime(time: NSTimeInterval) -> Bool {
     return (time >= 0)
 }

--- a/OneTimePassword/Token.URLSerializer.swift
+++ b/OneTimePassword/Token.URLSerializer.swift
@@ -122,7 +122,7 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
         else { return nil }
 
     let core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
-    guard core.isValid
+    guard core._isValid
         else { return nil }
 
     var name = Token.defaultName

--- a/OneTimePassword/Token.URLSerializer.swift
+++ b/OneTimePassword/Token.URLSerializer.swift
@@ -81,20 +81,6 @@ private func urlForToken(name name: String, issuer: String, factor: Generator.Fa
     return urlComponents.URL
 }
 
-// https://github.com/google/google-authenticator/blob/56ea6af49c958d4b8056e3c26b3c163841abb900/mobile/ios/Classes/OTPGenerator.m#L80
-// https://github.com/google/google-authenticator/blob/56ea6af49c958d4b8056e3c26b3c163841abb900/mobile/ios/Classes/TOTPGenerator.m#L41
-public func validateGeneratorWithGoogleRules(generator: Generator) -> Bool {
-    let validDigits: (Int) -> Bool = { (6 <= $0) && ($0 <= 8) }
-    let validPeriod: (NSTimeInterval) -> Bool = { (0 < $0) && ($0 <= 300) }
-
-    switch generator.factor {
-    case .Counter:
-        return validDigits(generator.digits)
-    case .Timer(let period):
-        return validDigits(generator.digits) && validPeriod(period)
-    }
-}
-
 private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> Token? {
     guard url.scheme == kOTPAuthScheme
         else { return nil }
@@ -136,8 +122,6 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
         else { return nil }
 
     let core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
-    guard validateGeneratorWithGoogleRules(core)
-        else { return nil }
 
     var name = Token.defaultName
     if let path = url.path {

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -68,7 +68,7 @@ public final class OTPToken: NSObject {
     }
 
     public func validate() -> Bool {
-        return token.core._isValid
+        return validateGeneratorWithGoogleRules(token.core)
     }
 }
 

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -84,7 +84,11 @@ public extension OTPToken {
 
     // This should be private, but is public for testing purposes
     func generatePasswordForCounter(counter: UInt64) -> String? {
-        return generatePassword(algorithm: token.core.algorithm, digits: token.core.digits, secret: token.core.secret, counter: counter)
+        do {
+            return try generatePassword(algorithm: token.core.algorithm, digits: token.core.digits, secret: token.core.secret, counter: counter)
+        } catch {
+            return nil
+        }
     }
 }
 

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -99,6 +99,7 @@ public extension OTPToken {
 
     static func tokenWithURL(url: NSURL, secret: NSData?) -> Self? {
         guard let token = Token.URLSerializer.deserialize(url.absoluteString, secret: secret)
+            where validateGeneratorWithGoogleRules(token.core)
             else { return nil }
 
         let otp = self.init()
@@ -172,3 +173,18 @@ public extension OTPToken {
         return self.tokenWithKeychainItem(keychainItem)
     }
 }
+
+// https://github.com/google/google-authenticator/blob/56ea6af49c958d4b8056e3c26b3c163841abb900/mobile/ios/Classes/OTPGenerator.m#L80
+// https://github.com/google/google-authenticator/blob/56ea6af49c958d4b8056e3c26b3c163841abb900/mobile/ios/Classes/TOTPGenerator.m#L41
+private func validateGeneratorWithGoogleRules(generator: Generator) -> Bool {
+    let validDigits: (Int) -> Bool = { (6 <= $0) && ($0 <= 8) }
+    let validPeriod: (NSTimeInterval) -> Bool = { (0 < $0) && ($0 <= 300) }
+
+    switch generator.factor {
+    case .Counter:
+        return validDigits(generator.digits)
+    case .Timer(let period):
+        return validDigits(generator.digits) && validPeriod(period)
+    }
+}
+

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -68,7 +68,7 @@ public final class OTPToken: NSObject {
     }
 
     public func validate() -> Bool {
-        return token.core.isValid
+        return token.core._isValid
     }
 }
 

--- a/OneTimePasswordTests/GeneratorTests.swift
+++ b/OneTimePasswordTests/GeneratorTests.swift
@@ -94,12 +94,13 @@ class GeneratorTests: XCTestCase {
         let digitTests: [(Int, Bool)] = [
             (-6, false),
             (0, false),
-            (1, false),
-            (5, false),
+            (1, true),
+            (5, true),
             (6, true),
             (7, true),
             (8, true),
-            (9, false),
+            (9, true),
+            (10, false),
         ]
 
         let periodTests: [(NSTimeInterval, Bool)] = [

--- a/OneTimePasswordTests/GeneratorTests.swift
+++ b/OneTimePasswordTests/GeneratorTests.swift
@@ -86,7 +86,7 @@ class GeneratorTests: XCTestCase {
         ]
 
         for (factor, timeInterval, counter) in factors {
-            XCTAssertEqual(counterForGeneratorWithFactor(factor, atTimeIntervalSince1970: timeInterval), counter)
+            XCTAssertEqual(try! counterForGeneratorWithFactor(factor, atTimeIntervalSince1970: timeInterval), counter)
         }
     }
 

--- a/OneTimePasswordTests/GeneratorTests.swift
+++ b/OneTimePasswordTests/GeneratorTests.swift
@@ -137,7 +137,7 @@ class GeneratorTests: XCTestCase {
         let expectedValues = ["755224", "287082", "359152", "969429", "338314", "254676", "287922", "162583", "399871", "520489"]
 
         for (var counter = 0; counter < expectedValues.count; counter++) {
-            XCTAssertEqual(generatePassword(algorithm: .SHA1, digits: 6, secret: secret, counter: UInt64(counter))!, expectedValues[counter])
+            XCTAssertEqual(generatePassword(algorithm: .SHA1, digits: 6, secret: secret, counter: UInt64(counter)), expectedValues[counter])
         }
     }
 
@@ -164,7 +164,7 @@ class GeneratorTests: XCTestCase {
             for (var i = 0; i < times.count; i++) {
                 if let password = expectedValues[algorithm]?[i] {
                     let counter = UInt64(times[i] / 30)
-                    XCTAssertEqual(generatePassword(algorithm: algorithm, digits: 8, secret: secret, counter: counter)!, password, "Incorrect result for \(algorithm) at \(times[i])")
+                    XCTAssertEqual(generatePassword(algorithm: algorithm, digits: 8, secret: secret, counter: counter), password, "Incorrect result for \(algorithm) at \(times[i])")
                 }
             }
         }
@@ -185,7 +185,7 @@ class GeneratorTests: XCTestCase {
         for (algorithm, values) in expectedValues {
             for (var i = 0; i < times.count; i++) {
                 let counter = UInt64(times[i] / 30)
-                XCTAssertEqual(values[i], generatePassword(algorithm: algorithm, digits: 6, secret: secret, counter: counter)!,
+                XCTAssertEqual(values[i], generatePassword(algorithm: algorithm, digits: 6, secret: secret, counter: counter),
                     "Incorrect result for \(algorithm) at \(times[i])")
             }
         }

--- a/OneTimePasswordTests/GeneratorTests.swift
+++ b/OneTimePasswordTests/GeneratorTests.swift
@@ -137,7 +137,7 @@ class GeneratorTests: XCTestCase {
         let expectedValues = ["755224", "287082", "359152", "969429", "338314", "254676", "287922", "162583", "399871", "520489"]
 
         for (var counter = 0; counter < expectedValues.count; counter++) {
-            XCTAssertEqual(generatePassword(algorithm: .SHA1, digits: 6, secret: secret, counter: UInt64(counter)), expectedValues[counter])
+            XCTAssertEqual(try! generatePassword(algorithm: .SHA1, digits: 6, secret: secret, counter: UInt64(counter)), expectedValues[counter])
         }
     }
 
@@ -164,7 +164,7 @@ class GeneratorTests: XCTestCase {
             for (var i = 0; i < times.count; i++) {
                 if let password = expectedValues[algorithm]?[i] {
                     let counter = UInt64(times[i] / 30)
-                    XCTAssertEqual(generatePassword(algorithm: algorithm, digits: 8, secret: secret, counter: counter), password, "Incorrect result for \(algorithm) at \(times[i])")
+                    XCTAssertEqual(try! generatePassword(algorithm: algorithm, digits: 8, secret: secret, counter: counter), password, "Incorrect result for \(algorithm) at \(times[i])")
                 }
             }
         }
@@ -185,7 +185,7 @@ class GeneratorTests: XCTestCase {
         for (algorithm, values) in expectedValues {
             for (var i = 0; i < times.count; i++) {
                 let counter = UInt64(times[i] / 30)
-                XCTAssertEqual(values[i], generatePassword(algorithm: algorithm, digits: 6, secret: secret, counter: counter),
+                XCTAssertEqual(values[i], try! generatePassword(algorithm: algorithm, digits: 6, secret: secret, counter: counter),
                     "Incorrect result for \(algorithm) at \(times[i])")
             }
         }

--- a/OneTimePasswordTests/GeneratorTests.swift
+++ b/OneTimePasswordTests/GeneratorTests.swift
@@ -109,7 +109,7 @@ class GeneratorTests: XCTestCase {
             (1, true),
             (30, true),
             (300, true),
-            (301, false),
+            (301, true),
         ]
 
         for (digits, digitsAreValid) in digitTests {

--- a/OneTimePasswordTests/GeneratorTests.swift
+++ b/OneTimePasswordTests/GeneratorTests.swift
@@ -115,17 +115,17 @@ class GeneratorTests: XCTestCase {
         for (digits, digitsAreValid) in digitTests {
             let generator = Generator(factor: .Counter(0), secret: NSData(), digits: digits)
             if digitsAreValid {
-                XCTAssertTrue(generator.isValid)
+                XCTAssertNotNil(generator.password)
             } else {
-                XCTAssertFalse(generator.isValid)
+                XCTAssertNil(generator.password)
             }
 
             for (period, periodIsValid) in periodTests {
                 let generator = Generator(factor: .Timer(period: period), secret: NSData(), digits: digits)
                 if (digitsAreValid && periodIsValid) {
-                    XCTAssertTrue(generator.isValid)
+                    XCTAssertNotNil(generator.password)
                 } else {
-                    XCTAssertFalse(generator.isValid)
+                    XCTAssertNil(generator.password)
                 }
             }
         }


### PR DESCRIPTION
Remove validation on `Generator` and replace it with safety checks at generation time. The acceptable values for these checks are defined by what values the algorithm can handle without an error, rather than arbitrarily constraining the `Generator` properties.
The old validation rules are moved to the legacy `OTPToken`.