### PR TITLE
Remove Generator Defaults

### DIFF
--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -62,11 +62,6 @@ public struct Generator: Equatable {
     public enum Algorithm: Equatable {
         case SHA1, SHA256, SHA512
     }
-
-    @available(*, deprecated=2.0)
-    public static let defaultAlgorithm: Algorithm = .SHA1
-    @available(*, deprecated=2.0)
-    public static let defaultDigits: Int = 6
 }
 
 public func ==(lhs: Generator, rhs: Generator) -> Bool {

--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -63,7 +63,9 @@ public struct Generator: Equatable {
         case SHA1, SHA256, SHA512
     }
 
+    @available(*, deprecated=2.0)
     public static let defaultAlgorithm: Algorithm = .SHA1
+    @available(*, deprecated=2.0)
     public static let defaultDigits: Int = 6
 }
 

--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -28,12 +28,12 @@ public struct Generator: Equatable {
 
     - parameter factor:      The moving factor
     - parameter secret:      The shared secret
-    - parameter algorithm:   The cryptographic hash function (defaults to SHA-1)
-    - parameter digits:      The number of digits in the password (defaults to 6)
+    - parameter algorithm:   The cryptographic hash function
+    - parameter digits:      The number of digits in the password
 
     - returns: A valid password generator, or `nil` if the parameters are invalid.
     */
-    public init(factor: Factor, secret: NSData, algorithm: Algorithm = defaultAlgorithm, digits: Int = defaultDigits) {
+    public init(factor: Factor, secret: NSData, algorithm: Algorithm, digits: Int) {
         self.factor = factor
         self.secret = secret
         self.algorithm = algorithm

--- a/OneTimePassword/Token.URLSerializer.swift
+++ b/OneTimePassword/Token.URLSerializer.swift
@@ -11,6 +11,9 @@ import Base32
 
 extension Token {
     public struct URLSerializer: TokenSerializer {
+        public static let defaultAlgorithm: Generator.Algorithm = .SHA1
+        public static let defaultDigits: Int = 6
+
         public static func serialize(token: Token) -> String? {
             let url = urlForToken(name: token.name, issuer: token.issuer, factor: token.core.factor, algorithm: token.core.algorithm, digits: token.core.digits)
             return url?.absoluteString
@@ -117,8 +120,8 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
 
     guard let factor = parse(url.host, with: factorParser, defaultTo: nil),
         let secret = parse(queryDictionary[kQuerySecretKey], with: { MF_Base32Codec.dataFromBase32String($0) }, overrideWith: externalSecret),
-        let algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Generator.defaultAlgorithm),
-        let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Generator.defaultDigits)
+        let algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Token.URLSerializer.defaultAlgorithm),
+        let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Token.URLSerializer.defaultDigits)
         else { return nil }
 
     let core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -29,11 +29,11 @@ public final class OTPToken: NSObject {
 
 
     public static var defaultAlgorithm: OTPAlgorithm {
-        return OTPAlgorithm(Generator.defaultAlgorithm)
+        return OTPAlgorithm.SHA1
     }
 
     public static var defaultDigits: UInt {
-        return UInt(Generator.defaultDigits)
+        return 6
     }
 
     public static var defaultInitialCounter: UInt64 {

--- a/OneTimePasswordTests/EquatableTests.swift
+++ b/OneTimePasswordTests/EquatableTests.swift
@@ -40,16 +40,16 @@ class EquatableTests: XCTestCase {
     func testGeneratorEquality() {
         let g = Generator(factor: .Counter(0), secret: NSData(), algorithm: .SHA1, digits: 6)
 
-        XCTAssert(g == Generator(factor: .Counter(0), secret: NSData()))
-        XCTAssert(g != Generator(factor: .Counter(1), secret: NSData()))
-        XCTAssert(g != Generator(factor: .Counter(0), secret: "0".dataUsingEncoding(NSUTF8StringEncoding)!))
-        XCTAssert(g != Generator(factor: .Counter(0), secret: NSData(), algorithm: .SHA256))
-        XCTAssert(g != Generator(factor: .Counter(0), secret: NSData(), digits: 8))
+        XCTAssert(g == Generator(factor: .Counter(0), secret: NSData(), algorithm: .SHA1, digits: 6))
+        XCTAssert(g != Generator(factor: .Counter(1), secret: NSData(), algorithm: .SHA1, digits: 6))
+        XCTAssert(g != Generator(factor: .Counter(0), secret: "0".dataUsingEncoding(NSUTF8StringEncoding)!, algorithm: .SHA1, digits: 6))
+        XCTAssert(g != Generator(factor: .Counter(0), secret: NSData(), algorithm: .SHA256, digits: 6))
+        XCTAssert(g != Generator(factor: .Counter(0), secret: NSData(), algorithm: .SHA1, digits: 8))
     }
 
     func testTokenEquality() {
-        let generator = Generator(factor: .Counter(0), secret: NSData())
-        let other_generator = Generator(factor: .Counter(1), secret: NSData())
+        let generator = Generator(factor: .Counter(0), secret: NSData(), algorithm: .SHA1, digits: 6)
+        let other_generator = Generator(factor: .Counter(1), secret: NSData(), algorithm: .SHA512, digits: 8)
 
         let t = Token(name: "Name", issuer: "Issuer", core: generator)
 

--- a/OneTimePasswordTests/GeneratorTests.swift
+++ b/OneTimePasswordTests/GeneratorTests.swift
@@ -54,24 +54,6 @@ class GeneratorTests: XCTestCase {
         XCTAssert(generator.digits != other_generator.digits)
     }
 
-    func testDefaults() {
-        let f = OneTimePassword.Generator.Factor.Counter(111)
-        let s = "12345678901234567890".dataUsingEncoding(NSASCIIStringEncoding)!
-        let a = Generator.Algorithm.SHA256
-        let d = 8
-
-        let generatorWithDefaultAlgorithm = Generator(factor: f, secret: s, digits: d)
-        let generatorWithDefaultDigits    = Generator(factor: f, secret: s, algorithm: a)
-
-        XCTAssert(generatorWithDefaultAlgorithm.algorithm == Generator.Algorithm.SHA1)
-        XCTAssert(generatorWithDefaultDigits.digits == 6)
-
-        let generatorWithAllDefaults = Generator(factor: f, secret: s)
-
-        XCTAssert(generatorWithAllDefaults.algorithm == Generator.Algorithm.SHA1)
-        XCTAssert(generatorWithAllDefaults.digits == 6)
-    }
-
     func testCounter() {
         let factors: [(OneTimePassword.Generator.Factor, NSTimeInterval, UInt64)] = [
             (.Counter(0),           -1,             0),
@@ -113,7 +95,12 @@ class GeneratorTests: XCTestCase {
         ]
 
         for (digits, digitsAreValid) in digitTests {
-            let generator = Generator(factor: .Counter(0), secret: NSData(), digits: digits)
+            let generator = Generator(
+                factor: .Counter(0),
+                secret: NSData(),
+                algorithm: .SHA1,
+                digits: digits
+            )
             if digitsAreValid {
                 XCTAssertNotNil(generator.password)
             } else {
@@ -121,7 +108,12 @@ class GeneratorTests: XCTestCase {
             }
 
             for (period, periodIsValid) in periodTests {
-                let generator = Generator(factor: .Timer(period: period), secret: NSData(), digits: digits)
+                let generator = Generator(
+                    factor: .Timer(period: period),
+                    secret: NSData(),
+                    algorithm: .SHA1,
+                    digits: digits
+                )
                 if (digitsAreValid && periodIsValid) {
                     XCTAssertNotNil(generator.password)
                 } else {

--- a/OneTimePasswordTests/TokenTests.swift
+++ b/OneTimePasswordTests/TokenTests.swift
@@ -16,7 +16,9 @@ class TokenTests: XCTestCase {
         let issuer = "Test Issuer"
         let generator = Generator(
             factor: .Counter(111),
-            secret: "12345678901234567890".dataUsingEncoding(NSASCIIStringEncoding)!
+            secret: "12345678901234567890".dataUsingEncoding(NSASCIIStringEncoding)!,
+            algorithm: .SHA1,
+            digits: 6
         )
 
         let token = Token(
@@ -34,7 +36,9 @@ class TokenTests: XCTestCase {
         let other_issuer = "Other Test Issuer"
         let other_generator = Generator(
             factor: .Timer(period: 123),
-            secret: "09876543210987654321".dataUsingEncoding(NSASCIIStringEncoding)!
+            secret: "09876543210987654321".dataUsingEncoding(NSASCIIStringEncoding)!,
+            algorithm: .SHA512,
+            digits: 8
         )
 
         let other_token = Token(
@@ -54,7 +58,12 @@ class TokenTests: XCTestCase {
     }
 
     func testDefaults() {
-        let generator = Generator(factor: .Counter(0), secret: NSData())
+        let generator = Generator(
+            factor: .Counter(0),
+            secret: NSData(),
+            algorithm: .SHA1,
+            digits: 6
+        )
         let n = "Test Name"
         let i = "Test Issuer"
 


### PR DESCRIPTION
The `Generator` shouldn't have default values for its `algorithm` or `digits` properties; it should always be initialized with the full set of parameters for password generation. The `URLSerializer` *does* need default values, as specified by the [URI format](https://github.com/google/google-authenticator/wiki/Key-Uri-Format).

This pull request removes the defaults from the generator, moves them to the serializer, and gives `OTPToken` its own legacy defaults. The tests are updated accordingly.