### PR TITLE
Renaming

### DIFF
--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -51,7 +51,7 @@ public struct Generator: Equatable {
 
     - returns: The current password, or `nil` if a password could not be generated.
     */
-    public var password: String? {
+    public var currentPassword: String? {
         do {
             return try passwordAtTimeIntervalSince1970(NSDate().timeIntervalSince1970)
         } catch {

--- a/OneTimePassword/Token.URLSerializer.swift
+++ b/OneTimePassword/Token.URLSerializer.swift
@@ -15,7 +15,13 @@ extension Token {
         public static let defaultDigits: Int = 6
 
         public static func serialize(token: Token) -> NSURL? {
-            return urlForToken(name: token.name, issuer: token.issuer, factor: token.core.factor, algorithm: token.core.algorithm, digits: token.core.digits)
+            return urlForToken(
+                name: token.name,
+                issuer: token.issuer,
+                factor: token.generator.factor,
+                algorithm: token.generator.algorithm,
+                digits: token.generator.digits
+            )
         }
 
         public static func deserialize(url: NSURL, secret: NSData? = nil) -> Token? {
@@ -120,7 +126,7 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
         let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Token.URLSerializer.defaultDigits)
         else { return nil }
 
-    let core = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
+    let generator = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
 
     var name = Token.defaultName
     if let path = url.path {
@@ -146,7 +152,7 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
         }
     }
 
-    return Token(name: name, issuer: issuer, core: core)
+    return Token(name: name, issuer: issuer, generator: generator)
 }
 
 private func parse<P, T>(item: P?, with parser: (P -> T?), defaultTo defaultValue: T? = nil, overrideWith overrideValue: T? = nil) -> T? {

--- a/OneTimePassword/Token.swift
+++ b/OneTimePassword/Token.swift
@@ -18,21 +18,21 @@ public struct Token: Equatable {
     public let issuer: String
 
     /// A password generator containing this token's secret, algorithm, etc.
-    public let core: Generator
+    public let generator: Generator
 
     /**
     Initializes a new token with the given parameters.
 
-    - parameter name:        The account name for the token (defaults to "")
-    - parameter issure:      The entity which issued the token (defaults to "")
-    - parameter core:        The password generator
+    - parameter name:       The account name for the token (defaults to "")
+    - parameter issure:     The entity which issued the token (defaults to "")
+    - parameter generator:  The password generator
 
     - returns: A new token with the given parameters.
     */
-    public init(name: String = defaultName, issuer: String = defaultIssuer, core: Generator) {
+    public init(name: String = defaultName, issuer: String = defaultIssuer, generator: Generator) {
         self.name = name
         self.issuer = issuer
-        self.core = core
+        self.generator = generator
     }
 
     // MARK: Defaults
@@ -48,7 +48,7 @@ public struct Token: Equatable {
 public func ==(lhs: Token, rhs: Token) -> Bool {
     return (lhs.name == rhs.name)
         && (lhs.issuer == rhs.issuer)
-        && (lhs.core == rhs.core)
+        && (lhs.generator == rhs.generator)
 }
 
 /**
@@ -56,15 +56,15 @@ public func ==(lhs: Token, rhs: Token) -> Bool {
 - returns: A new token, configured to generate the next password.
 */
 public func updatedToken(token: Token) -> Token {
-    switch token.core.factor {
+    switch token.generator.factor {
     case .Counter(let counter):
         let updatedGenerator = Generator(
             factor: .Counter(counter + 1),
-            secret: token.core.secret,
-            algorithm: token.core.algorithm,
-            digits: token.core.digits
+            secret: token.generator.secret,
+            algorithm: token.generator.algorithm,
+            digits: token.generator.digits
         )
-        return Token(name: token.name, issuer: token.issuer, core: updatedGenerator)
+        return Token(name: token.name, issuer: token.issuer, generator: updatedGenerator)
     case .Timer:
         return token
     }

--- a/OneTimePassword/TokenPersistence.swift
+++ b/OneTimePassword/TokenPersistence.swift
@@ -102,7 +102,7 @@ public func addTokenToKeychain(token: Token) -> Token.KeychainItem? {
 
     let attributes = [
         kSecAttrGeneric as String:  data,
-        kSecValueData as String:    token.core.secret,
+        kSecValueData as String:    token.generator.secret,
         kSecAttrService as String:  kOTPService,
     ]
 

--- a/OneTimePasswordLegacy/Conversion.swift
+++ b/OneTimePasswordLegacy/Conversion.swift
@@ -27,7 +27,7 @@ internal func tokenForOTPToken(token: OTPToken) -> Token {
         algorithm: algorithmForOTPAlgorithm(token.algorithm),
         digits: Int(token.digits)
     )
-    return Token(name: token.name, issuer: token.issuer, core: generator)
+    return Token(name: token.name, issuer: token.issuer, generator: generator)
 }
 
 private func factorForOTPToken(token: OTPToken) -> Generator.Factor {

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -79,7 +79,7 @@ public final class OTPToken: NSObject {
 
 public extension OTPToken {
     var password: String? {
-        return token.generator.password
+        return token.generator.currentPassword
     }
 
     func updatePassword() {

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -53,11 +53,11 @@ public final class OTPToken: NSObject {
         self.name = token.name
         self.issuer = token.issuer
 
-        self.secret = token.core.secret
-        self.algorithm = OTPAlgorithm(token.core.algorithm)
-        self.digits = UInt(token.core.digits)
+        self.secret = token.generator.secret
+        self.algorithm = OTPAlgorithm(token.generator.algorithm)
+        self.digits = UInt(token.generator.digits)
 
-        switch token.core.factor {
+        switch token.generator.factor {
         case let .Counter(counter):
             self.type = .Counter
             self.counter = counter
@@ -73,13 +73,13 @@ public final class OTPToken: NSObject {
     }
 
     public func validate() -> Bool {
-        return validateGeneratorWithGoogleRules(token.core)
+        return validateGeneratorWithGoogleRules(token.generator)
     }
 }
 
 public extension OTPToken {
     var password: String? {
-        return token.core.password
+        return token.generator.password
     }
 
     func updatePassword() {
@@ -95,7 +95,7 @@ public extension OTPToken {
 
     static func tokenWithURL(url: NSURL, secret: NSData?) -> Self? {
         guard let token = Token.URLSerializer.deserialize(url, secret: secret)
-            where validateGeneratorWithGoogleRules(token.core)
+            where validateGeneratorWithGoogleRules(token.generator)
             else { return nil }
 
         return self.init(token: token)

--- a/OneTimePasswordTests/EquatableTests.swift
+++ b/OneTimePasswordTests/EquatableTests.swift
@@ -51,11 +51,11 @@ class EquatableTests: XCTestCase {
         let generator = Generator(factor: .Counter(0), secret: NSData(), algorithm: .SHA1, digits: 6)
         let other_generator = Generator(factor: .Counter(1), secret: NSData(), algorithm: .SHA512, digits: 8)
 
-        let t = Token(name: "Name", issuer: "Issuer", core: generator)
+        let t = Token(name: "Name", issuer: "Issuer", generator: generator)
 
-        XCTAssertEqual(t, Token(name: "Name", issuer: "Issuer", core: generator))
-        XCTAssertNotEqual(t, Token(name: "", issuer: "Issuer", core: generator))
-        XCTAssertNotEqual(t, Token(name: "Name", issuer: "", core: generator))
-        XCTAssertNotEqual(t, Token(name: "Name", issuer: "Issuer", core: other_generator))
+        XCTAssertEqual(t, Token(name: "Name", issuer: "Issuer", generator: generator))
+        XCTAssertNotEqual(t, Token(name: "", issuer: "Issuer", generator: generator))
+        XCTAssertNotEqual(t, Token(name: "Name", issuer: "", generator: generator))
+        XCTAssertNotEqual(t, Token(name: "Name", issuer: "Issuer", generator: other_generator))
     }
 }

--- a/OneTimePasswordTests/GeneratorTests.swift
+++ b/OneTimePasswordTests/GeneratorTests.swift
@@ -102,9 +102,9 @@ class GeneratorTests: XCTestCase {
                 digits: digits
             )
             if digitsAreValid {
-                XCTAssertNotNil(generator.password)
+                XCTAssertNotNil(generator.currentPassword)
             } else {
-                XCTAssertNil(generator.password)
+                XCTAssertNil(generator.currentPassword)
             }
 
             for (period, periodIsValid) in periodTests {
@@ -115,9 +115,9 @@ class GeneratorTests: XCTestCase {
                     digits: digits
                 )
                 if (digitsAreValid && periodIsValid) {
-                    XCTAssertNotNil(generator.password)
+                    XCTAssertNotNil(generator.currentPassword)
                 } else {
-                    XCTAssertNil(generator.password)
+                    XCTAssertNil(generator.currentPassword)
                 }
             }
         }
@@ -141,7 +141,7 @@ class GeneratorTests: XCTestCase {
         ]
         for (counter, expectedPassword) in expectedValues {
             let generator = Generator(factor: .Counter(counter), secret: secret, algorithm: .SHA1, digits: 6)
-            XCTAssertEqual(generator.password, expectedPassword, "The generator did not produce the expected OTP.")
+            XCTAssertEqual(generator.currentPassword, expectedPassword, "The generator did not produce the expected OTP.")
         }
     }
 

--- a/OneTimePasswordTests/TokenSerializationTests.swift
+++ b/OneTimePasswordTests/TokenSerializationTests.swift
@@ -46,7 +46,7 @@ class TokenSerializationTests: XCTestCase {
                                 let token = Token(
                                     name: name,
                                     issuer: issuer,
-                                    core: generator
+                                    generator: generator
                                 )
 
                                 // Serialize

--- a/OneTimePasswordTests/TokenTests.swift
+++ b/OneTimePasswordTests/TokenTests.swift
@@ -24,12 +24,12 @@ class TokenTests: XCTestCase {
         let token = Token(
             name: name,
             issuer: issuer,
-            core: generator
+            generator: generator
         )
 
         XCTAssertEqual(token.name, name)
         XCTAssertEqual(token.issuer, issuer)
-        XCTAssertEqual(token.core, generator)
+        XCTAssertEqual(token.generator, generator)
 
         // Create another token
         let other_name = "Other Test Name"
@@ -44,17 +44,17 @@ class TokenTests: XCTestCase {
         let other_token = Token(
             name: other_name,
             issuer: other_issuer,
-            core: other_generator
+            generator: other_generator
         )
 
         XCTAssertEqual(other_token.name, other_name)
         XCTAssertEqual(other_token.issuer, other_issuer)
-        XCTAssertEqual(other_token.core, other_generator)
+        XCTAssertEqual(other_token.generator, other_generator)
 
         // Ensure the tokens are different
         XCTAssertNotEqual(token.name, other_token.name)
         XCTAssertNotEqual(token.issuer, other_token.issuer)
-        XCTAssertNotEqual(token.core, other_token.core)
+        XCTAssertNotEqual(token.generator, other_token.generator)
     }
 
     func testDefaults() {
@@ -67,15 +67,15 @@ class TokenTests: XCTestCase {
         let n = "Test Name"
         let i = "Test Issuer"
 
-        let tokenWithDefaultName = Token(issuer: i, core: generator)
+        let tokenWithDefaultName = Token(issuer: i, generator: generator)
         XCTAssertEqual(tokenWithDefaultName.name, "")
         XCTAssertEqual(tokenWithDefaultName.issuer, i)
 
-        let tokenWithDefaultIssuer = Token(name: n, core: generator)
+        let tokenWithDefaultIssuer = Token(name: n, generator: generator)
         XCTAssertEqual(tokenWithDefaultIssuer.name, n)
         XCTAssertEqual(tokenWithDefaultIssuer.issuer, "")
 
-        let tokenWithAllDefaults = Token(core: generator)
+        let tokenWithAllDefaults = Token(generator: generator)
         XCTAssertEqual(tokenWithAllDefaults.name, "")
         XCTAssertEqual(tokenWithAllDefaults.issuer, "")
     }


### PR DESCRIPTION
 - Rename `OTPToken`'s `core` to `generator`.
 - Rename `Generator`'s `password` to `currentPassword`. This should help remind the user that the value returned from this property is not constant and may vary over time.