### PR TITLE
Validate Generator on Initialization

### DIFF
--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -33,7 +33,7 @@ public struct Generator: Equatable {
 
     - returns: A new password generator with the given parameters.
     */
-    public init(factor: Factor, secret: NSData, algorithm: Algorithm, digits: Int) {
+    public init?(factor: Factor, secret: NSData, algorithm: Algorithm, digits: Int) {
         self.factor = factor
         self.secret = secret
         self.algorithm = algorithm

--- a/OneTimePassword/Generator.swift
+++ b/OneTimePassword/Generator.swift
@@ -34,6 +34,9 @@ public struct Generator: Equatable {
     - returns: A new password generator with the given parameters.
     */
     public init?(factor: Factor, secret: NSData, algorithm: Algorithm, digits: Int) {
+        guard validateFactor(factor) && validateDigits(digits) else {
+            return nil
+        }
         self.factor = factor
         self.secret = secret
         self.algorithm = algorithm

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -15,30 +15,21 @@ internal enum GenerationError: ErrorType {
     case InvalidDigits
 }
 
-func validateDigits(digits: Int) throws -> Int {
+func validateDigits(digits: Int) -> Bool {
     // https://tools.ietf.org/html/rfc4226#section-5.3
     // "Implementations MUST extract a 6-digit code at a minimum and possibly 7 and 8-digit codes."
     let acceptableDigits = 6...8
-    guard acceptableDigits.contains(digits) else {
-        throw GenerationError.InvalidDigits
-    }
-    return digits
+    return acceptableDigits.contains(digits)
 }
 
-func validatePeriod(period: NSTimeInterval) throws -> NSTimeInterval {
+func validatePeriod(period: NSTimeInterval) -> Bool {
     // The period must be positive and non-zero to produce a valid counter value.
-    guard period > 0 else {
-        throw GenerationError.InvalidPeriod
-    }
-    return period
+    return (period > 0)
 }
 
-func validateTime(timeInterval: NSTimeInterval) throws -> NSTimeInterval {
+func validateTime(timeInterval: NSTimeInterval) -> Bool {
     // The time interval must be positive to produce a valid counter value.
-    guard timeInterval >= 0 else {
-        throw GenerationError.InvalidTime
-    }
-    return timeInterval
+    return (timeInterval >= 0)
 }
 
 internal func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeIntervalSince1970 timeInterval: NSTimeInterval) throws -> UInt64 {
@@ -46,14 +37,20 @@ internal func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeInte
     case .Counter(let counter):
         return counter
     case .Timer(let period):
-        try validateTime(timeInterval)
-        try validatePeriod(period)
+        guard validateTime(timeInterval) else {
+            throw GenerationError.InvalidTime
+        }
+        guard validatePeriod(period) else {
+            throw GenerationError.InvalidPeriod
+        }
         return UInt64(timeInterval / period)
     }
 }
 
 internal func generatePassword(algorithm algorithm: Generator.Algorithm, digits: Int, secret: NSData, counter: UInt64) throws -> String {
-    try validateDigits(digits)
+    guard validateDigits(digits) else {
+        throw GenerationError.InvalidDigits
+    }
 
     func hashInfoForAlgorithm(algorithm: Generator.Algorithm) -> (algorithm: CCHmacAlgorithm, length: Int) {
         switch algorithm {

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -15,6 +15,15 @@ internal enum GenerationError: ErrorType {
     case InvalidDigits
 }
 
+func validateDigits(digits: Int) throws {
+    // https://tools.ietf.org/html/rfc4226#section-5.3
+    // "Implementations MUST extract a 6-digit code at a minimum and possibly 7 and 8-digit codes."
+    let acceptableDigits = 6...8
+    guard acceptableDigits.contains(digits) else {
+        throw GenerationError.InvalidDigits
+    }
+}
+
 internal func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeIntervalSince1970 timeInterval: NSTimeInterval) throws -> UInt64 {
     switch factor {
     case .Counter(let counter):
@@ -33,11 +42,7 @@ internal func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeInte
 }
 
 internal func generatePassword(algorithm algorithm: Generator.Algorithm, digits: Int, secret: NSData, counter: UInt64) throws -> String {
-    // Zero or negative digits makes no sense, 10 digits overflows UInt32.max
-    let acceptableDigits = 1...9
-    guard acceptableDigits.contains(digits) else {
-        throw GenerationError.InvalidDigits
-    }
+    try validateDigits(digits)
 
     func hashInfoForAlgorithm(algorithm: Generator.Algorithm) -> (algorithm: CCHmacAlgorithm, length: Int) {
         switch algorithm {

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -22,6 +22,15 @@ func validateDigits(digits: Int) -> Bool {
     return acceptableDigits.contains(digits)
 }
 
+func validateFactor(factor: Generator.Factor) -> Bool {
+    switch factor {
+    case .Counter:
+        return true
+    case .Timer(let period):
+        return validatePeriod(period)
+    }
+}
+
 func validatePeriod(period: NSTimeInterval) -> Bool {
     // The period must be positive and non-zero to produce a valid counter value.
     return (period > 0)

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -24,19 +24,27 @@ func validateDigits(digits: Int) throws {
     }
 }
 
+func validatePeriod(period: NSTimeInterval) throws {
+    // The period must be positive and non-zero to produce a valid counter value.
+    guard period > 0 else {
+        throw GenerationError.InvalidPeriod
+    }
+}
+
+func validateTime(timeIntervalSince1970: NSTimeInterval) throws {
+    // The time interval must be positive to produce a valid counter value.
+    guard timeIntervalSince1970 >= 0 else {
+        throw GenerationError.InvalidTime
+    }
+}
+
 internal func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeIntervalSince1970 timeInterval: NSTimeInterval) throws -> UInt64 {
     switch factor {
     case .Counter(let counter):
         return counter
     case .Timer(let period):
-        // The time interval must be positive to produce a valid counter value.
-        guard timeInterval >= 0 else {
-            throw GenerationError.InvalidTime
-        }
-        // The period must be positive and non-zero to produce a valid counter value.
-        guard period > 0 else {
-            throw GenerationError.InvalidPeriod
-        }
+        try validateTime(timeInterval)
+        try validatePeriod(period)
         return UInt64(timeInterval / period)
     }
 }

--- a/OneTimePassword/GeneratorFunctions.swift
+++ b/OneTimePassword/GeneratorFunctions.swift
@@ -15,27 +15,30 @@ internal enum GenerationError: ErrorType {
     case InvalidDigits
 }
 
-func validateDigits(digits: Int) throws {
+func validateDigits(digits: Int) throws -> Int {
     // https://tools.ietf.org/html/rfc4226#section-5.3
     // "Implementations MUST extract a 6-digit code at a minimum and possibly 7 and 8-digit codes."
     let acceptableDigits = 6...8
     guard acceptableDigits.contains(digits) else {
         throw GenerationError.InvalidDigits
     }
+    return digits
 }
 
-func validatePeriod(period: NSTimeInterval) throws {
+func validatePeriod(period: NSTimeInterval) throws -> NSTimeInterval {
     // The period must be positive and non-zero to produce a valid counter value.
     guard period > 0 else {
         throw GenerationError.InvalidPeriod
     }
+    return period
 }
 
-func validateTime(timeIntervalSince1970: NSTimeInterval) throws {
+func validateTime(timeInterval: NSTimeInterval) throws -> NSTimeInterval {
     // The time interval must be positive to produce a valid counter value.
-    guard timeIntervalSince1970 >= 0 else {
+    guard timeInterval >= 0 else {
         throw GenerationError.InvalidTime
     }
+    return timeInterval
 }
 
 internal func counterForGeneratorWithFactor(factor: Generator.Factor, atTimeIntervalSince1970 timeInterval: NSTimeInterval) throws -> UInt64 {

--- a/OneTimePassword/Token.URLSerializer.swift
+++ b/OneTimePassword/Token.URLSerializer.swift
@@ -128,11 +128,10 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
     guard let factor = parse(url.host, with: factorParser, defaultTo: nil),
         let secret = parse(queryDictionary[kQuerySecretKey], with: { MF_Base32Codec.dataFromBase32String($0) }, overrideWith: externalSecret),
         let algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: Token.URLSerializer.defaultAlgorithm),
-        let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Token.URLSerializer.defaultDigits) else {
+        let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: Token.URLSerializer.defaultDigits),
+        let generator = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits) else {
             return nil
     }
-
-    let generator = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits)
 
     var name = Token.defaultName
     if let path = url.path {

--- a/OneTimePassword/Token.swift
+++ b/OneTimePassword/Token.swift
@@ -72,15 +72,17 @@ public func == (lhs: Token, rhs: Token) -> Bool {
 - parameter token:   The current token
 - returns: A new token, configured to generate the next password.
 */
-public func updatedToken(token: Token) -> Token {
+public func updatedToken(token: Token) -> Token? {
     switch token.generator.factor {
     case .Counter(let counter):
-        let updatedGenerator = Generator(
+        guard let updatedGenerator = Generator(
             factor: .Counter(counter + 1),
             secret: token.generator.secret,
             algorithm: token.generator.algorithm,
             digits: token.generator.digits
-        )
+        ) else {
+            return nil
+        }
         return Token(name: token.name, issuer: token.issuer, generator: updatedGenerator)
     case .Timer:
         return token

--- a/OneTimePasswordLegacy/Conversion.swift
+++ b/OneTimePasswordLegacy/Conversion.swift
@@ -20,13 +20,15 @@ internal extension OTPAlgorithm {
 }
 
 
-internal func tokenForOTPToken(otpToken: OTPToken) -> Token {
-    let generator = Generator(
+internal func tokenForOTPToken(otpToken: OTPToken) -> Token? {
+    guard let generator = Generator(
         factor: factorForOTPToken(otpToken),
         secret: otpToken.secret,
         algorithm: algorithmForOTPAlgorithm(otpToken.algorithm),
         digits: Int(otpToken.digits)
-    )
+    ) else {
+        return nil
+    }
     return Token(name: otpToken.name, issuer: otpToken.issuer, generator: generator)
 }
 

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -96,9 +96,8 @@ public extension OTPToken {
     }
 
     static func tokenWithURL(url: NSURL, secret: NSData?) -> Self? {
-        guard let token = Token.URLSerializer.deserialize(url, secret: secret)
-            where validateGeneratorWithGoogleRules(token.generator) else {
-                return nil
+        guard let token = Token.URLSerializer.deserialize(url, secret: secret) else {
+            return nil
         }
         return self.init(token: token)
     }
@@ -170,19 +169,5 @@ public extension OTPToken {
             return nil
         }
         return self.tokenWithKeychainItem(keychainItem)
-    }
-}
-
-// https://github.com/google/google-authenticator/blob/56ea6af49c958d4b8056e3c26b3c163841abb900/mobile/ios/Classes/OTPGenerator.m#L80
-// https://github.com/google/google-authenticator/blob/56ea6af49c958d4b8056e3c26b3c163841abb900/mobile/ios/Classes/TOTPGenerator.m#L41
-private func validateGeneratorWithGoogleRules(generator: Generator) -> Bool {
-    let validDigits: (Int) -> Bool = { (6 <= $0) && ($0 <= 8) }
-    let validPeriod: (NSTimeInterval) -> Bool = { (0 < $0) && ($0 <= 300) }
-
-    switch generator.factor {
-    case .Counter:
-        return validDigits(generator.digits)
-    case .Timer(let period):
-        return validDigits(generator.digits) && validPeriod(period)
     }
 }

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -45,7 +45,7 @@ public final class OTPToken: NSObject {
     }
 
 
-    public var token: Token {
+    public var token: Token? {
         return tokenForOTPToken(self)
     }
 
@@ -73,18 +73,20 @@ public final class OTPToken: NSObject {
     }
 
     public func validate() -> Bool {
-        return validateGeneratorWithGoogleRules(token.generator)
+        return (token != nil)
     }
 }
 
 public extension OTPToken {
     var password: String? {
-        return token.currentPassword
+        return token?.currentPassword
     }
 
     func updatePassword() {
-        let newToken = updatedToken(token)
-        updateWithToken(newToken)
+        if let token = token,
+            let newToken = updatedToken(token) {
+                updateWithToken(newToken)
+        }
     }
 }
 
@@ -102,6 +104,9 @@ public extension OTPToken {
     }
 
     func url() -> NSURL? {
+        guard let token = token else {
+            return nil
+        }
         return Token.URLSerializer.serialize(token)
     }
 }
@@ -111,6 +116,9 @@ public extension OTPToken {
     var isInKeychain: Bool { return (keychainItemRef != nil) }
 
     func saveToKeychain() -> Bool {
+        guard let token = token else {
+            return false
+        }
         if let keychainItem = self.keychainItem {
             guard let newKeychainItem = updateKeychainItem(keychainItem, withToken: token) else {
                 return false

--- a/OneTimePasswordLegacyTests/OTPTokenSerializationTests.m
+++ b/OneTimePasswordLegacyTests/OTPTokenSerializationTests.m
@@ -239,6 +239,12 @@ static const unsigned char kValidSecret[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05
                                     // Serialize
                                     NSURL *url = token.url;
 
+                                    // An invalid token should not (cannot) produce a URL
+                                    if (![token validate]) {
+                                        XCTAssertNil(url);
+                                        continue;
+                                    }
+
                                     // Test scheme
                                     XCTAssertEqualObjects(url.scheme, kOTPScheme,
                                                           @"The url scheme should be \"%@\"", kOTPScheme);

--- a/OneTimePasswordTests/EquatableTests.swift
+++ b/OneTimePasswordTests/EquatableTests.swift
@@ -48,8 +48,11 @@ class EquatableTests: XCTestCase {
     }
 
     func testTokenEquality() {
-        let generator = Generator(factor: .Counter(0), secret: NSData(), algorithm: .SHA1, digits: 6)
-        let other_generator = Generator(factor: .Counter(1), secret: NSData(), algorithm: .SHA512, digits: 8)
+        guard let generator = Generator(factor: .Counter(0), secret: NSData(), algorithm: .SHA1, digits: 6),
+            let other_generator = Generator(factor: .Counter(1), secret: NSData(), algorithm: .SHA512, digits: 8) else {
+                XCTFail()
+                return
+        }
 
         let t = Token(name: "Name", issuer: "Issuer", generator: generator)
 

--- a/OneTimePasswordTests/GeneratorTests.swift
+++ b/OneTimePasswordTests/GeneratorTests.swift
@@ -24,10 +24,10 @@ class GeneratorTests: XCTestCase {
             digits: digits
         )
 
-        XCTAssert(generator.factor == factor)
-        XCTAssert(generator.secret == secret)
-        XCTAssert(generator.algorithm == algorithm)
-        XCTAssert(generator.digits == digits)
+        XCTAssertEqual(generator?.factor, factor)
+        XCTAssertEqual(generator?.secret, secret)
+        XCTAssertEqual(generator?.algorithm, algorithm)
+        XCTAssertEqual(generator?.digits, digits)
 
         // Create another generator
         let other_factor = OneTimePassword.Generator.Factor.Timer(period: 123)
@@ -42,16 +42,16 @@ class GeneratorTests: XCTestCase {
             digits: other_digits
         )
 
-        XCTAssert(other_generator.factor == other_factor)
-        XCTAssert(other_generator.secret == other_secret)
-        XCTAssert(other_generator.algorithm == other_algorithm)
-        XCTAssert(other_generator.digits == other_digits)
+        XCTAssertEqual(other_generator?.factor, other_factor)
+        XCTAssertEqual(other_generator?.secret, other_secret)
+        XCTAssertEqual(other_generator?.algorithm, other_algorithm)
+        XCTAssertEqual(other_generator?.digits, other_digits)
 
         // Ensure the generators are different
-        XCTAssert(generator.factor != other_generator.factor)
-        XCTAssert(generator.secret != other_generator.secret)
-        XCTAssert(generator.algorithm != other_generator.algorithm)
-        XCTAssert(generator.digits != other_generator.digits)
+        XCTAssertNotEqual(generator?.factor, other_generator?.factor)
+        XCTAssertNotEqual(generator?.secret, other_generator?.secret)
+        XCTAssertNotEqual(generator?.algorithm, other_generator?.algorithm)
+        XCTAssertNotEqual(generator?.digits, other_generator?.digits)
     }
 
     func testCounter() {
@@ -103,11 +103,10 @@ class GeneratorTests: XCTestCase {
             )
             // If the digits are invalid, password generation should throw an error
             let generatorIsValid = digitsAreValid
-            do {
-                try generator.passwordAtTimeIntervalSince1970(0)
-                XCTAssertTrue(generatorIsValid)
-            } catch {
-                XCTAssertFalse(generatorIsValid)
+            if generatorIsValid {
+                XCTAssertNotNil(generator)
+            } else {
+                XCTAssertNil(generator)
             }
 
             for (period, periodIsValid) in periodTests {
@@ -119,11 +118,10 @@ class GeneratorTests: XCTestCase {
                 )
                 // If the digits or period are invalid, password generation should throw an error
                 let generatorIsValid = digitsAreValid && periodIsValid
-                do {
-                    try generator.passwordAtTimeIntervalSince1970(0)
-                    XCTAssertTrue(generatorIsValid)
-                } catch {
-                    XCTAssertFalse(generatorIsValid)
+                if generatorIsValid {
+                    XCTAssertNotNil(generator)
+                } else {
+                    XCTAssertNil(generator)
                 }
             }
         }
@@ -147,7 +145,7 @@ class GeneratorTests: XCTestCase {
         ]
         for (counter, expectedPassword) in expectedValues {
             let generator = Generator(factor: .Counter(counter), secret: secret, algorithm: .SHA1, digits: 6)
-            XCTAssertEqual(expectedPassword, try! generator.passwordAtTimeIntervalSince1970(0),
+            XCTAssertEqual(expectedPassword, try! generator!.passwordAtTimeIntervalSince1970(0),
                 "The generator did not produce the expected OTP.")
         }
     }
@@ -175,7 +173,7 @@ class GeneratorTests: XCTestCase {
 
             for i in 0..<times.count {
                 let expectedPassword = expectedValues[algorithm]?[i]
-                let password = try! generator.passwordAtTimeIntervalSince1970(times[i])
+                let password = try! generator!.passwordAtTimeIntervalSince1970(times[i])
                 XCTAssertEqual(password, expectedPassword,
                     "Incorrect result for \(algorithm) at \(times[i])")
             }
@@ -198,7 +196,7 @@ class GeneratorTests: XCTestCase {
             let generator = Generator(factor: .Timer(period: 30), secret: secret, algorithm: algorithm, digits: 6)
             for i in 0..<times.count {
                 let expectedPassword = expectedPasswords[i]
-                let password = try! generator.passwordAtTimeIntervalSince1970(times[i])
+                let password = try! generator!.passwordAtTimeIntervalSince1970(times[i])
                 XCTAssertEqual(password, expectedPassword,
                     "Incorrect result for \(algorithm) at \(times[i])")
             }

--- a/OneTimePasswordTests/GeneratorTests.swift
+++ b/OneTimePasswordTests/GeneratorTests.swift
@@ -76,12 +76,12 @@ class GeneratorTests: XCTestCase {
         let digitTests: [(Int, Bool)] = [
             (-6, false),
             (0, false),
-            (1, true),
-            (5, true),
+            (1, false),
+            (5, false),
             (6, true),
             (7, true),
             (8, true),
-            (9, true),
+            (9, false),
             (10, false),
         ]
 

--- a/OneTimePasswordTests/TokenSerializationTests.swift
+++ b/OneTimePasswordTests/TokenSerializationTests.swift
@@ -36,12 +36,15 @@ class TokenSerializationTests: XCTestCase {
                         for algorithm in algorithms {
                             for digitNumber in digits {
                                 // Create the token
-                                let generator = Generator(
+                                guard let generator = Generator(
                                     factor: factor,
                                     secret: secretString.dataUsingEncoding(NSASCIIStringEncoding)!,
                                     algorithm: algorithm,
                                     digits: digitNumber
-                                )
+                                ) else {
+                                    XCTFail()
+                                    continue
+                                }
 
                                 let token = Token(
                                     name: name,

--- a/OneTimePasswordTests/TokenTests.swift
+++ b/OneTimePasswordTests/TokenTests.swift
@@ -14,12 +14,15 @@ class TokenTests: XCTestCase {
         // Create a token
         let name = "Test Name"
         let issuer = "Test Issuer"
-        let generator = Generator(
+        guard let generator = Generator(
             factor: .Counter(111),
             secret: "12345678901234567890".dataUsingEncoding(NSASCIIStringEncoding)!,
             algorithm: .SHA1,
             digits: 6
-        )
+        ) else {
+            XCTFail()
+            return
+        }
 
         let token = Token(
             name: name,
@@ -34,12 +37,15 @@ class TokenTests: XCTestCase {
         // Create another token
         let other_name = "Other Test Name"
         let other_issuer = "Other Test Issuer"
-        let other_generator = Generator(
+        guard let other_generator = Generator(
             factor: .Timer(period: 123),
             secret: "09876543210987654321".dataUsingEncoding(NSASCIIStringEncoding)!,
             algorithm: .SHA512,
             digits: 8
-        )
+        ) else {
+            XCTFail()
+            return
+        }
 
         let other_token = Token(
             name: other_name,
@@ -58,12 +64,15 @@ class TokenTests: XCTestCase {
     }
 
     func testDefaults() {
-        let generator = Generator(
+        guard let generator = Generator(
             factor: .Counter(0),
             secret: NSData(),
             algorithm: .SHA1,
             digits: 6
-        )
+        ) else {
+            XCTFail()
+            return
+        }
         let n = "Test Name"
         let i = "Test Issuer"
 


### PR DESCRIPTION
Convert `Generator.init` to a failable initializer that validates the generation parameters. By doing so, the immutable `Generator` becomes a type where *invalid states are impossible* to initialize. If a `Generator` exists, it can produce a password.

Also:
 - Tighten the range of acceptable password lengths
 - Loosen the restrictions on valid timer periods