### PR TITLE
Keychain errors

### DIFF
--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -48,10 +48,7 @@ public final class Keychain {
     ///
     /// - throws: A `Keychain.Error` if an error occurred.
     public func allPersistentTokens() throws -> [PersistentToken] {
-        guard let keychainItems = try allKeychainItems() as? [NSDictionary] else {
-            throw Error.IncorrectReturnType
-        }
-        return keychainItems.flatMap({ PersistentToken(keychainDictionary: $0) })
+        return try allKeychainItems().flatMap({ PersistentToken(keychainDictionary: $0) })
     }
 
     // MARK: Write
@@ -219,7 +216,7 @@ private func keychainItemForPersistentRef(persistentRef: NSData) throws -> NSDic
     return keychainItem
 }
 
-private func allKeychainItems() throws -> NSArray {
+private func allKeychainItems() throws -> [NSDictionary] {
     let queryDict = [
         kSecClass as String:                kSecClassGenericPassword,
         kSecMatchLimit as String:           kSecMatchLimitAll,
@@ -240,7 +237,7 @@ private func allKeychainItems() throws -> NSArray {
     guard resultCode == errSecSuccess else {
         throw Keychain.Error.SystemError(resultCode)
     }
-    guard let keychainItems = result as? NSArray else {
+    guard let keychainItems = result as? [NSDictionary] else {
         throw Keychain.Error.IncorrectReturnType
     }
     return keychainItems

--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -37,6 +37,7 @@ public final class Keychain {
     ///
     /// - parameter token: The persistent identifier for the desired token.
     ///
+    /// - throws: A `Keychain.Error` if an error occurred.
     /// - returns: The persistent token, or `nil` if no token matched the given identifier.
     public func persistentTokenWithIdentifier(identifier: NSData) throws -> PersistentToken? {
         return try keychainItemForPersistentRef(identifier)
@@ -44,6 +45,8 @@ public final class Keychain {
     }
 
     /// Returns an array of all persistent tokens found in the keychain.
+    ///
+    /// - throws: A `Keychain.Error` if an error occurred.
     public func allPersistentTokens() throws -> [PersistentToken] {
         guard let keychainItems = try allKeychainItems() as? [NSDictionary] else {
             throw Error.IncorrectReturnType
@@ -57,7 +60,8 @@ public final class Keychain {
     ///
     /// - parameter token: The token to save to the keychain.
     ///
-    /// - returns: The new persistent token, or `nil` if an error has occured.
+    /// - throws: A `Keychain.Error` if the token was not added successfully.
+    /// - returns: The new persistent token.
     public func addToken(token: Token) throws -> PersistentToken {
         guard let attributes = token.keychainAttributes else {
             throw Error.TokenSerializationFailure
@@ -71,7 +75,8 @@ public final class Keychain {
     /// - parameter persistentToken: The persistent token to update.
     /// - parameter token: The new token value.
     ///
-    /// - returns: The updated persistent token, or `nil` if an error has occured.
+    /// - throws: A `Keychain.Error` if the update did not succeed.
+    /// - returns: The updated persistent token.
     public func updatePersistentToken(persistentToken: PersistentToken,
         withToken token: Token) throws -> PersistentToken
     {
@@ -90,7 +95,7 @@ public final class Keychain {
     ///
     /// - parameter persistentToken: The persistent token to delete.
     ///
-    /// - returns: A boolean indicating whether the token was successfully deleted.
+    /// - throws: A `Keychain.Error` if the deletion did not succeed.
     public func deletePersistentToken(persistentToken: PersistentToken) throws {
         try deleteKeychainItemForPersistentRef(persistentToken.identifier)
     }

--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -94,8 +94,8 @@ public final class Keychain {
     /// - parameter persistentToken: The persistent token to delete.
     ///
     /// - returns: A boolean indicating whether the token was successfully deleted.
-    public func deletePersistentToken(persistentToken: PersistentToken) -> Bool {
-        return deleteKeychainItemForPersistentRef(persistentToken.identifier)
+    public func deletePersistentToken(persistentToken: PersistentToken) throws {
+        try deleteKeychainItemForPersistentRef(persistentToken.identifier)
     }
 
     // MARK: Errors
@@ -173,14 +173,17 @@ private func updateKeychainItemForPersistentRef(persistentRef: NSData,
     return (resultCode == OSStatus(errSecSuccess))
 }
 
-private func deleteKeychainItemForPersistentRef(persistentRef: NSData) -> Bool {
+private func deleteKeychainItemForPersistentRef(persistentRef: NSData) throws {
     let queryDict = [
         kSecClass as String:               kSecClassGenericPassword,
         kSecValuePersistentRef as String:  persistentRef,
     ]
 
     let resultCode = SecItemDelete(queryDict)
-    return (resultCode == OSStatus(errSecSuccess))
+
+    guard resultCode == errSecSuccess else {
+        throw Keychain.Error.SystemError(resultCode)
+    }
 }
 
 private func keychainItemForPersistentRef(persistentRef: NSData) throws -> NSDictionary? {

--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -63,9 +63,7 @@ public final class Keychain {
     /// - throws: A `Keychain.Error` if the token was not added successfully.
     /// - returns: The new persistent token.
     public func addToken(token: Token) throws -> PersistentToken {
-        guard let attributes = token.keychainAttributes else {
-            throw Error.TokenSerializationFailure
-        }
+        let attributes = try token.keychainAttributes()
         let persistentRef = try addKeychainItemWithAttributes(attributes)
         return PersistentToken(token: token, identifier: persistentRef)
     }
@@ -80,9 +78,7 @@ public final class Keychain {
     public func updatePersistentToken(persistentToken: PersistentToken,
         withToken token: Token) throws -> PersistentToken
     {
-        guard let attributes = token.keychainAttributes else {
-            throw Error.TokenSerializationFailure
-        }
+        let attributes = try token.keychainAttributes()
         try updateKeychainItemForPersistentRef(persistentToken.identifier,
             withAttributes: attributes)
         return PersistentToken(token: token, identifier: persistentToken.identifier)
@@ -114,10 +110,10 @@ public final class Keychain {
 private let kOTPService = "me.mattrubin.onetimepassword.token"
 
 private extension Token {
-    private var keychainAttributes: [String: AnyObject]? {
+    private func keychainAttributes() throws -> [String: AnyObject] {
         guard let url = Token.URLSerializer.serialize(self),
             let data = url.absoluteString.dataUsingEncoding(NSUTF8StringEncoding) else {
-                return nil
+                throw Keychain.Error.TokenSerializationFailure
         }
         return [
             kSecAttrGeneric as String:  data,

--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -134,11 +134,8 @@ private extension PersistentToken {
     }
 }
 
-private func addKeychainItemWithAttributes(attributes: NSDictionary) throws -> NSData {
-    guard let mutableAttributes = attributes.mutableCopy() as? NSMutableDictionary else {
-        // Not quite the correct error to throw here, but this should truly never fail...
-        throw Keychain.Error.IncorrectReturnType
-    }
+private func addKeychainItemWithAttributes(attributes: [String: AnyObject]) throws -> NSData {
+    var mutableAttributes = attributes
     mutableAttributes[kSecClass as String] = kSecClassGenericPassword
     mutableAttributes[kSecReturnPersistentRef as String] = kCFBooleanTrue
     // Set a random string for the account name.
@@ -162,7 +159,7 @@ private func addKeychainItemWithAttributes(attributes: NSDictionary) throws -> N
 }
 
 private func updateKeychainItemForPersistentRef(persistentRef: NSData,
-    withAttributes attributesToUpdate: NSDictionary) throws
+    withAttributes attributesToUpdate: [String: AnyObject]) throws
 {
     let queryDict = [
         kSecClass as String:               kSecClassGenericPassword,

--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -38,17 +38,15 @@ public final class Keychain {
     /// - parameter token: The persistent identifier for the desired token.
     ///
     /// - returns: The persistent token, or `nil` if no token matched the given identifier.
-    public func persistentTokenWithIdentifier(identifier: NSData) -> PersistentToken? {
-        guard let result = try? keychainItemForPersistentRef(identifier) else {
-            return nil
-        }
-        return PersistentToken(keychainDictionary: result)
+    public func persistentTokenWithIdentifier(identifier: NSData) throws -> PersistentToken? {
+        return try keychainItemForPersistentRef(identifier)
+            .flatMap({ PersistentToken(keychainDictionary: $0) })
     }
 
     /// Returns an array of all persistent tokens found in the keychain.
-    public func allPersistentTokens() -> [PersistentToken]? {
-        guard let keychainItems = (try? allKeychainItems()) as? [NSDictionary] else {
-            return nil
+    public func allPersistentTokens() throws -> [PersistentToken] {
+        guard let keychainItems = try allKeychainItems() as? [NSDictionary] else {
+            throw Keychain.Error.IncorrectReturnType
         }
         return keychainItems.flatMap({ PersistentToken(keychainDictionary: $0) })
     }

--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -185,7 +185,7 @@ private func deleteKeychainItemForPersistentRef(persistentRef: NSData) -> Bool {
     return (resultCode == OSStatus(errSecSuccess))
 }
 
-private func keychainItemForPersistentRef(persistentRef: NSData) throws -> NSDictionary {
+private func keychainItemForPersistentRef(persistentRef: NSData) throws -> NSDictionary? {
     let queryDict = [
         kSecClass as String:                kSecClassGenericPassword,
         kSecValuePersistentRef as String:   persistentRef,
@@ -199,6 +199,10 @@ private func keychainItemForPersistentRef(persistentRef: NSData) throws -> NSDic
         SecItemCopyMatching(queryDict, $0)
     }
 
+    if resultCode == errSecItemNotFound {
+        // Not finding any keychain items is not an error in this case. Return nil.
+        return nil
+    }
     guard resultCode == errSecSuccess else {
         throw Keychain.Error.SystemError(resultCode)
     }

--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -40,15 +40,14 @@ public final class Keychain {
     /// - throws: A `Keychain.Error` if an error occurred.
     /// - returns: The persistent token, or `nil` if no token matched the given identifier.
     public func persistentTokenWithIdentifier(identifier: NSData) throws -> PersistentToken? {
-        return try keychainItemForPersistentRef(identifier)
-            .flatMap({ PersistentToken(keychainDictionary: $0) })
+        return try keychainItemForPersistentRef(identifier).flatMap(PersistentToken.init)
     }
 
     /// Returns an array of all persistent tokens found in the keychain.
     ///
     /// - throws: A `Keychain.Error` if an error occurred.
     public func allPersistentTokens() throws -> [PersistentToken] {
-        return try allKeychainItems().flatMap({ PersistentToken(keychainDictionary: $0) })
+        return try allKeychainItems().flatMap(PersistentToken.init)
     }
 
     // MARK: Write

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -120,7 +120,8 @@ public extension OTPToken {
         }
         if let keychainItem = self.keychainItem {
             do {
-                let newKeychainItem = try Keychain.sharedInstance.updatePersistentToken(keychainItem, withToken: token)
+                let newKeychainItem = try Keychain.sharedInstance
+                    .updatePersistentToken(keychainItem, withToken: token)
                 self.keychainItem = newKeychainItem
                 return true
             } catch {

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -127,11 +127,13 @@ public extension OTPToken {
                 return false
             }
         } else {
-            guard let newKeychainItem = Keychain.sharedInstance.addToken(token) else {
+            do {
+                let newKeychainItem = try Keychain.sharedInstance.addToken(token)
+                self.keychainItem = newKeychainItem
+                return true
+            } catch {
                 return false
             }
-            self.keychainItem = newKeychainItem
-            return true
         }
     }
 

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -138,11 +138,13 @@ public extension OTPToken {
         guard let keychainItem = self.keychainItem else {
             return false
         }
-        let success = Keychain.sharedInstance.deletePersistentToken(keychainItem)
-        if success {
+        do {
+            try Keychain.sharedInstance.deletePersistentToken(keychainItem)
             self.keychainItem = nil
+            return true
+        } catch {
+            return false
         }
-        return success
     }
 
     static func allTokensInKeychain() -> Array<OTPToken> {

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -146,7 +146,11 @@ public extension OTPToken {
     }
 
     static func allTokensInKeychain() -> Array<OTPToken> {
-        return Keychain.sharedInstance.allPersistentTokens()?.map(self.tokenWithKeychainItem) ?? []
+        do {
+            return try Keychain.sharedInstance.allPersistentTokens().map(self.tokenWithKeychainItem)
+        } catch {
+            return []
+        }
     }
 
     private static func tokenWithKeychainItem(keychainItem: PersistentToken) -> Self {

--- a/OneTimePasswordLegacy/OTPToken.swift
+++ b/OneTimePasswordLegacy/OTPToken.swift
@@ -119,12 +119,13 @@ public extension OTPToken {
             return false
         }
         if let keychainItem = self.keychainItem {
-            guard let newKeychainItem = Keychain.sharedInstance.updatePersistentToken(keychainItem,
-                withToken: token) else {
-                    return false
+            do {
+                let newKeychainItem = try Keychain.sharedInstance.updatePersistentToken(keychainItem, withToken: token)
+                self.keychainItem = newKeychainItem
+                return true
+            } catch {
+                return false
             }
-            self.keychainItem = newKeychainItem
-            return true
         } else {
             guard let newKeychainItem = Keychain.sharedInstance.addToken(token) else {
                 return false

--- a/OneTimePasswordTests/TokenPersistenceTests.swift
+++ b/OneTimePasswordTests/TokenPersistenceTests.swift
@@ -66,13 +66,15 @@ class TokenPersistenceTests: XCTestCase {
         // Modify the token
         let modifiedToken = Token(name: "???", issuer: "!", generator: token.generator.successor())
 
-        guard let modifiedKeychainItem = keychain.updatePersistentToken(keychainItem,
-            withToken: modifiedToken) else {
-                XCTFail("Failed to update keychain with modified token")
-                return
+        do {
+            let modifiedKeychainItem = try keychain.updatePersistentToken(keychainItem,
+                withToken: modifiedToken)
+            XCTAssertEqual(modifiedKeychainItem.identifier, keychainItem.identifier)
+            XCTAssertEqual(modifiedKeychainItem.token, modifiedToken)
+        } catch {
+            XCTFail("Failed to update keychain with modified token")
+            return
         }
-        XCTAssertEqual(modifiedKeychainItem.identifier, keychainItem.identifier)
-        XCTAssertEqual(modifiedKeychainItem.token, modifiedToken)
 
         // Fetch the token again
         guard let thirdKeychainItem = try keychain.persistentTokenWithIdentifier(keychainItem.identifier) else {

--- a/OneTimePasswordTests/TokenPersistenceTests.swift
+++ b/OneTimePasswordTests/TokenPersistenceTests.swift
@@ -251,12 +251,7 @@ class TokenPersistenceTests: XCTestCase {
 
         do {
             let itemsRemaining = try keychain.allPersistentTokens()
-            XCTAssertNil(itemFromArray(itemsRemaining, withPersistentRef: savedItem1.identifier),
-                "Token not removed from keychain: \(token1)")
-            XCTAssertNil(itemFromArray(itemsRemaining, withPersistentRef: savedItem2.identifier),
-                "Token not removed from keychain: \(token2)")
-            XCTAssertNil(itemFromArray(itemsRemaining, withPersistentRef: savedItem3.identifier),
-                "Token not removed from keychain: \(token3)")
+            XCTAssert(itemsRemaining.isEmpty, "Array should be empty: \(itemsRemaining)")
         } catch {
             XCTFail("Error thrown from keychain: \(error)")
             return

--- a/OneTimePasswordTests/TokenPersistenceTests.swift
+++ b/OneTimePasswordTests/TokenPersistenceTests.swift
@@ -205,7 +205,6 @@ class TokenPersistenceTests: XCTestCase {
     }
 
     func testAllTokensInKeychain() {
-    do {
         guard let token1 = Token.URLSerializer.deserialize(kValidTokenURL),
             let token2 = Token.URLSerializer.deserialize(kValidTokenURL),
             let token3 = Token.URLSerializer.deserialize(kValidTokenURL) else {
@@ -213,21 +212,33 @@ class TokenPersistenceTests: XCTestCase {
                 return
         }
 
-        let noItems = try keychain.allPersistentTokens()
-        XCTAssert(noItems.isEmpty, "Array should be empty: \(noItems)")
+        do {
+            let noItems = try keychain.allPersistentTokens()
+            XCTAssert(noItems.isEmpty, "Array should be empty: \(noItems)")
+        } catch {
+            XCTFail("Error thrown from keychain: \(error)")
+            return
+        }
 
-        let savedItem1 = try keychain.addToken(token1)
-        let savedItem2 = try keychain.addToken(token2)
-        let savedItem3 = try keychain.addToken(token3)
+        guard let savedItem1 = try? keychain.addToken(token1),
+            let savedItem2 = try? keychain.addToken(token2),
+            let savedItem3 = try? keychain.addToken(token3) else {
+                XCTFail("Failed to save tokens")
+                return
+        }
 
-        let allItems = try keychain.allPersistentTokens()
-
-        XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem1.identifier),
-            "Token not recovered from keychain: \(token1)")
-        XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem2.identifier),
-            "Token not recovered from keychain: \(token2)")
-        XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem3.identifier),
-            "Token not recovered from keychain: \(token3)")
+        do {
+            let allItems = try keychain.allPersistentTokens()
+            XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem1.identifier),
+                "Token not recovered from keychain: \(token1)")
+            XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem2.identifier),
+                "Token not recovered from keychain: \(token2)")
+            XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem3.identifier),
+                "Token not recovered from keychain: \(token3)")
+        } catch {
+            XCTFail("Error thrown from keychain: \(error)")
+            return
+        }
 
         do {
             try keychain.deletePersistentToken(savedItem1)
@@ -238,17 +249,17 @@ class TokenPersistenceTests: XCTestCase {
             return
         }
 
-        let itemsRemaining = try keychain.allPersistentTokens()
-
-        XCTAssertNil(itemFromArray(itemsRemaining, withPersistentRef: savedItem1.identifier),
-            "Token not removed from keychain: \(token1)")
-        XCTAssertNil(itemFromArray(itemsRemaining, withPersistentRef: savedItem2.identifier),
-            "Token not removed from keychain: \(token2)")
-        XCTAssertNil(itemFromArray(itemsRemaining, withPersistentRef: savedItem3.identifier),
-            "Token not removed from keychain: \(token3)")
-    } catch {
-        XCTFail("Error thrown from keychain: \(error)")
-        return
-    }
+        do {
+            let itemsRemaining = try keychain.allPersistentTokens()
+            XCTAssertNil(itemFromArray(itemsRemaining, withPersistentRef: savedItem1.identifier),
+                "Token not removed from keychain: \(token1)")
+            XCTAssertNil(itemFromArray(itemsRemaining, withPersistentRef: savedItem2.identifier),
+                "Token not removed from keychain: \(token2)")
+            XCTAssertNil(itemFromArray(itemsRemaining, withPersistentRef: savedItem3.identifier),
+                "Token not removed from keychain: \(token3)")
+        } catch {
+            XCTFail("Error thrown from keychain: \(error)")
+            return
+        }
     }
 }

--- a/OneTimePasswordTests/TokenPersistenceTests.swift
+++ b/OneTimePasswordTests/TokenPersistenceTests.swift
@@ -50,10 +50,7 @@ class TokenPersistenceTests: XCTestCase {
         XCTAssertEqual(token.generator.secret, NSData(bytes: kValidSecret, length: kValidSecret.count))
 
         // Save the token
-        guard let keychainItem = keychain.addToken(token) else {
-            XCTFail("Failed to save token to keychain")
-            return
-        }
+        let keychainItem = try keychain.addToken(token)
 
         // Restore the token
         guard let secondKeychainItem = try keychain.persistentTokenWithIdentifier(keychainItem.identifier) else {
@@ -109,14 +106,8 @@ class TokenPersistenceTests: XCTestCase {
         }
 
         // Add both tokens to the keychain
-        guard let savedItem1 = keychain.addToken(token1) else {
-            XCTFail("Failed to save to keychain: \(token1)")
-            return
-        }
-        guard let savedItem2 = keychain.addToken(token2) else {
-            XCTFail("Failed to save to keychain: \(token2)")
-            return
-        }
+        let savedItem1 = try keychain.addToken(token1)
+        let savedItem2 = try keychain.addToken(token2)
         XCTAssertEqual(savedItem1.token, token1)
         XCTAssertEqual(savedItem2.token, token2)
 
@@ -197,12 +188,9 @@ class TokenPersistenceTests: XCTestCase {
         let noItems = try keychain.allPersistentTokens()
         XCTAssert(noItems.isEmpty, "Array should be empty: \(noItems)")
 
-        guard let savedItem1 = keychain.addToken(token1),
-            let savedItem2 = keychain.addToken(token2),
-            let savedItem3 = keychain.addToken(token3) else {
-                XCTFail("Failed to save tokens")
-                return
-        }
+        let savedItem1 = try keychain.addToken(token1)
+        let savedItem2 = try keychain.addToken(token2)
+        let savedItem3 = try keychain.addToken(token3)
 
         let allItems = try keychain.allPersistentTokens()
 

--- a/OneTimePasswordTests/TokenPersistenceTests.swift
+++ b/OneTimePasswordTests/TokenPersistenceTests.swift
@@ -63,7 +63,7 @@ class TokenPersistenceTests: XCTestCase {
             XCTAssertEqual(secondKeychainItem.token, keychainItem.token)
             XCTAssertEqual(secondKeychainItem.identifier, keychainItem.identifier)
         } catch {
-            XCTFail("Error thrown from keychain: \(error)")
+            XCTFail("persistentTokenWithIdentifier(_:) failed with error: \(error)")
             return
         }
 
@@ -76,7 +76,7 @@ class TokenPersistenceTests: XCTestCase {
             XCTAssertEqual(modifiedKeychainItem.identifier, keychainItem.identifier)
             XCTAssertEqual(modifiedKeychainItem.token, modifiedToken)
         } catch {
-            XCTFail("Failed to update keychain with modified token")
+            XCTFail("updatePersistentToken(_:withToken:) failed with error: \(error)")
             return
         }
 
@@ -89,7 +89,7 @@ class TokenPersistenceTests: XCTestCase {
             XCTAssertEqual(thirdKeychainItem.token, modifiedToken)
             XCTAssertEqual(thirdKeychainItem.identifier, keychainItem.identifier)
         } catch {
-            XCTFail("Error thrown from keychain: \(error)")
+            XCTFail("persistentTokenWithIdentifier(_:) failed with error: \(error)")
             return
         }
 
@@ -98,6 +98,7 @@ class TokenPersistenceTests: XCTestCase {
             try keychain.deletePersistentToken(keychainItem)
         } catch {
             XCTFail("deletePersistentToken(_:) failed with error: \(error)")
+            return
         }
 
         // Attempt to restore the deleted token
@@ -105,7 +106,7 @@ class TokenPersistenceTests: XCTestCase {
             let fourthKeychainItem = try keychain.persistentTokenWithIdentifier(keychainItem.identifier)
             XCTAssertNil(fourthKeychainItem)
         } catch {
-            XCTFail("Error thrown from keychain: \(error)")
+            XCTFail("persistentTokenWithIdentifier(_:) failed with error: \(error)")
             return
         }
     }
@@ -142,7 +143,7 @@ class TokenPersistenceTests: XCTestCase {
             XCTAssertEqual(savedItem1, fetchedItem1)
             XCTAssertEqual(savedItem2, fetchedItem2)
         } catch {
-            XCTFail("Error thrown from keychain: \(error)")
+            XCTFail("persistentTokenWithIdentifier(_:) failed with error: \(error)")
             return
         }
 
@@ -151,6 +152,7 @@ class TokenPersistenceTests: XCTestCase {
             try keychain.deletePersistentToken(savedItem1)
         } catch {
             XCTFail("deletePersistentToken(_:) failed with error: \(error)")
+            return
         }
 
         do {
@@ -159,7 +161,7 @@ class TokenPersistenceTests: XCTestCase {
             let checkItem2 = try keychain.persistentTokenWithIdentifier(savedItem2.identifier)
             XCTAssertNotNil(checkItem2, "Token should be in keychain: \(token2)")
         } catch {
-            XCTFail("Error thrown from keychain: \(error)")
+            XCTFail("persistentTokenWithIdentifier(_:) failed with error: \(error)")
             return
         }
 
@@ -168,6 +170,7 @@ class TokenPersistenceTests: XCTestCase {
             try keychain.deletePersistentToken(savedItem2)
         } catch {
             XCTFail("deletePersistentToken(_:) failed with error: \(error)")
+            return
         }
 
         do {
@@ -176,7 +179,7 @@ class TokenPersistenceTests: XCTestCase {
             let recheckItem2 = try keychain.persistentTokenWithIdentifier(savedItem2.identifier)
             XCTAssertNil(recheckItem2, "Token should not be in keychain: \(token2)")
         } catch {
-            XCTFail("Error thrown from keychain: \(error)")
+            XCTFail("persistentTokenWithIdentifier(_:) failed with error: \(error)")
             return
         }
 
@@ -186,6 +189,7 @@ class TokenPersistenceTests: XCTestCase {
             // The deletion should throw and this line should never be reached.
             XCTFail("Removing again should fail: \(token1)")
         } catch {
+            // This is the expected outcome
             // TODO: Assert the expected error type
         }
         do {
@@ -193,6 +197,7 @@ class TokenPersistenceTests: XCTestCase {
             // The deletion should throw and this line should never be reached.
             XCTFail("Removing again should fail: \(token2)")
         } catch {
+            // This is the expected outcome
             // TODO: Assert the expected error type
         }
     }
@@ -216,7 +221,7 @@ class TokenPersistenceTests: XCTestCase {
             let noItems = try keychain.allPersistentTokens()
             XCTAssert(noItems.isEmpty, "Array should be empty: \(noItems)")
         } catch {
-            XCTFail("Error thrown from keychain: \(error)")
+            XCTFail("allPersistentTokens() failed with error: \(error)")
             return
         }
 
@@ -236,7 +241,7 @@ class TokenPersistenceTests: XCTestCase {
             XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem3.identifier),
                 "Token not recovered from keychain: \(token3)")
         } catch {
-            XCTFail("Error thrown from keychain: \(error)")
+            XCTFail("allPersistentTokens() failed with error: \(error)")
             return
         }
 
@@ -253,7 +258,7 @@ class TokenPersistenceTests: XCTestCase {
             let itemsRemaining = try keychain.allPersistentTokens()
             XCTAssert(itemsRemaining.isEmpty, "Array should be empty: \(itemsRemaining)")
         } catch {
-            XCTFail("Error thrown from keychain: \(error)")
+            XCTFail("allPersistentTokens() failed with error: \(error)")
             return
         }
     }

--- a/OneTimePasswordTests/TokenPersistenceTests.swift
+++ b/OneTimePasswordTests/TokenPersistenceTests.swift
@@ -83,8 +83,11 @@ class TokenPersistenceTests: XCTestCase {
         XCTAssertEqual(thirdKeychainItem.identifier, keychainItem.identifier)
 
         // Remove the token
-        let success = keychain.deletePersistentToken(keychainItem)
-        XCTAssertTrue(success)
+        do {
+            try keychain.deletePersistentToken(keychainItem)
+        } catch {
+            XCTFail("deletePersistentToken(_:) failed with error: \(error)")
+        }
 
         // Attempt to restore the deleted token
         let fourthKeychainItem = try keychain.persistentTokenWithIdentifier(keychainItem.identifier)
@@ -128,8 +131,11 @@ class TokenPersistenceTests: XCTestCase {
         XCTAssertEqual(savedItem2, fetchedItem2)
 
         // Remove the first token from the keychain
-        let delete1success = keychain.deletePersistentToken(savedItem1)
-        XCTAssertTrue(delete1success, "Failed to remove from keychain: \(token1)")
+        do {
+            try keychain.deletePersistentToken(savedItem1)
+        } catch {
+            XCTFail("deletePersistentToken(_:) failed with error: \(error)")
+        }
 
         let checkItem1 = try keychain.persistentTokenWithIdentifier(savedItem1.identifier)
         XCTAssertNil(checkItem1, "Token should not be in keychain: \(token1)")
@@ -137,8 +143,11 @@ class TokenPersistenceTests: XCTestCase {
         XCTAssertNotNil(checkItem2, "Token should be in keychain: \(token2)")
 
         // Remove the second token from the keychain
-        let delete2success = keychain.deletePersistentToken(savedItem2)
-        XCTAssertTrue(delete2success, "Failed to remove from keychain: \(token2)")
+        do {
+            try keychain.deletePersistentToken(savedItem2)
+        } catch {
+            XCTFail("deletePersistentToken(_:) failed with error: \(error)")
+        }
 
         let recheckItem1 = try keychain.persistentTokenWithIdentifier(savedItem1.identifier)
         XCTAssertNil(recheckItem1, "Token should not be in keychain: \(token1)")
@@ -146,10 +155,21 @@ class TokenPersistenceTests: XCTestCase {
         XCTAssertNil(recheckItem2, "Token should not be in keychain: \(token2)")
 
         // Try to remove both tokens from the keychain again
-        let redelete1success = keychain.deletePersistentToken(savedItem1)
-        XCTAssertFalse(redelete1success, "Removing again should fail: \(token1)")
-        let redelete2success = keychain.deletePersistentToken(savedItem2)
-        XCTAssertFalse(redelete2success, "Removing again should fail: \(token2)")
+        do {
+            try keychain.deletePersistentToken(savedItem1)
+            // The deletion should throw and this line should never be reached.
+            XCTFail("Removing again should fail: \(token1)")
+        } catch {
+            // TODO: Assert the expected error type
+        }
+        do {
+            try keychain.deletePersistentToken(savedItem2)
+            // The deletion should throw and this line should never be reached.
+            XCTFail("Removing again should fail: \(token2)")
+        } catch {
+            // TODO: Assert the expected error type
+        }
+
     } catch {
         XCTFail("Error thrown from keychain: \(error)")
         return
@@ -191,11 +211,13 @@ class TokenPersistenceTests: XCTestCase {
         XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem3.identifier),
             "Token not recovered from keychain: \(token3)")
 
-        guard keychain.deletePersistentToken(savedItem1) &&
-            keychain.deletePersistentToken(savedItem2) &&
-            keychain.deletePersistentToken(savedItem3) else {
-                XCTFail("Failed to delete tokens")
-                return
+        do {
+            try keychain.deletePersistentToken(savedItem1)
+            try keychain.deletePersistentToken(savedItem2)
+            try keychain.deletePersistentToken(savedItem3)
+        } catch {
+            XCTFail("deletePersistentToken(_:) failed with error: \(error)")
+            return
         }
 
         let itemsRemaining = try keychain.allPersistentTokens()


### PR DESCRIPTION
When a `Sec*` keychain method returns an error result code, the wrapping keychain methods will now throw an error rather than just returning nil. This helps clarify the difference between methods returning no value as a valid result, and methods which throw errors in exceptional cases.