### PR TITLE
Persistent Token Set

### DIFF
--- a/OneTimePassword/Keychain.swift
+++ b/OneTimePassword/Keychain.swift
@@ -46,8 +46,8 @@ public final class Keychain {
     /// Returns an array of all persistent tokens found in the keychain.
     ///
     /// - throws: A `Keychain.Error` if an error occurred.
-    public func allPersistentTokens() throws -> [PersistentToken] {
-        return try allKeychainItems().flatMap(PersistentToken.init)
+    public func allPersistentTokens() throws -> Set<PersistentToken> {
+        return Set(try allKeychainItems().flatMap(PersistentToken.init))
     }
 
     // MARK: Write

--- a/OneTimePassword/PersistentToken.swift
+++ b/OneTimePassword/PersistentToken.swift
@@ -28,7 +28,7 @@ import Foundation
 /// A `PersistentToken` represents a `Token` stored in the `Keychain`. The keychain assigns each
 /// saved `token` a unique `identifier` which can be used to recover the token from the keychain at
 /// a later time.
-public struct PersistentToken: Equatable {
+public struct PersistentToken: Equatable, Hashable {
     /// A `Token` stored in the keychain.
     public let token: Token
     /// The keychain's persistent identifier for the saved token.
@@ -38,6 +38,12 @@ public struct PersistentToken: Equatable {
     internal init(token: Token, identifier: NSData) {
         self.token = token
         self.identifier = identifier
+    }
+
+    public var hashValue: Int {
+        // Since we expect every `PersistentToken`s identifier to be unique, the identifier's hash
+        // value makes a simple and adequate hash value for the struct as a whole.
+        return identifier.hashValue
     }
 }
 

--- a/OneTimePasswordTests/TokenPersistenceTests.swift
+++ b/OneTimePasswordTests/TokenPersistenceTests.swift
@@ -202,13 +202,6 @@ class TokenPersistenceTests: XCTestCase {
         }
     }
 
-    func itemFromArray(items: [PersistentToken], withPersistentRef persistentRef: NSData) -> PersistentToken? {
-        let matchingItems = items.filter({ $0.identifier == persistentRef })
-        XCTAssert((matchingItems.count <= 1),
-            "Found more than one matching token: \(matchingItems)")
-        return matchingItems.first
-    }
-
     func testAllTokensInKeychain() {
         guard let token1 = Token.URLSerializer.deserialize(kValidTokenURL),
             let token2 = Token.URLSerializer.deserialize(kValidTokenURL),
@@ -219,7 +212,7 @@ class TokenPersistenceTests: XCTestCase {
 
         do {
             let noItems = try keychain.allPersistentTokens()
-            XCTAssert(noItems.isEmpty, "Array should be empty: \(noItems)")
+            XCTAssert(noItems.isEmpty, "Expected no tokens in keychain: \(noItems)")
         } catch {
             XCTFail("allPersistentTokens() failed with error: \(error)")
             return
@@ -234,12 +227,8 @@ class TokenPersistenceTests: XCTestCase {
 
         do {
             let allItems = try keychain.allPersistentTokens()
-            XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem1.identifier),
-                "Token not recovered from keychain: \(token1)")
-            XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem2.identifier),
-                "Token not recovered from keychain: \(token2)")
-            XCTAssertNotNil(itemFromArray(allItems, withPersistentRef: savedItem3.identifier),
-                "Token not recovered from keychain: \(token3)")
+            XCTAssertEqual(allItems, [savedItem1, savedItem2, savedItem3],
+                "Tokens not correctly recovered from keychain")
         } catch {
             XCTFail("allPersistentTokens() failed with error: \(error)")
             return
@@ -256,7 +245,7 @@ class TokenPersistenceTests: XCTestCase {
 
         do {
             let itemsRemaining = try keychain.allPersistentTokens()
-            XCTAssert(itemsRemaining.isEmpty, "Array should be empty: \(itemsRemaining)")
+            XCTAssert(itemsRemaining.isEmpty, "Expected no tokens in keychain: \(itemsRemaining)")
         } catch {
             XCTFail("allPersistentTokens() failed with error: \(error)")
             return


### PR DESCRIPTION
Return a `Set`, rather than an `Array`, from `allPersistentTokens()`