### PR TITLE
Isolate Crypto

### DIFF
--- a/OneTimePassword.xcodeproj/project.pbxproj
+++ b/OneTimePassword.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		C9DC7EC4196BD5DF00B50C82 /* Token+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DC7EC3196BD5DF00B50C82 /* Token+URL.swift */; };
 		C9DC7EC8196BDF3B00B50C82 /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DC7EC7196BDF3B00B50C82 /* Generator.swift */; };
 		C9E639091BDDFF6B002D9231 /* OneTimePassword.h in Headers */ = {isa = PBXBuildFile; fileRef = C9377D40196B93F900D6C67E /* OneTimePassword.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C9F544AD1C8391630023CCF0 /* Crypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F544AC1C8391630023CCF0 /* Crypto.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +92,7 @@
 		C9E829531C62DFDA003F5FC9 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		C9E829541C62FFBD003F5FC9 /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		C9E829551C630514003F5FC9 /* CONDUCT.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONDUCT.md; sourceTree = "<group>"; };
+		C9F544AC1C8391630023CCF0 /* Crypto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Crypto.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,6 +181,7 @@
 			children = (
 				C93A2519196B1BA400F86892 /* Token.swift */,
 				C9DC7EC7196BDF3B00B50C82 /* Generator.swift */,
+				C9F544AC1C8391630023CCF0 /* Crypto.swift */,
 				C9307A8619A8522F00609B02 /* Serialization */,
 				C9A9B09A1A81EF4B00F3C4DC /* Persistence */,
 				C97C823B1946E51D00FD9F4C /* Supporting Files */,
@@ -468,6 +471,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C9F544AD1C8391630023CCF0 /* Crypto.swift in Sources */,
 				C93A251A196B1BA400F86892 /* Token.swift in Sources */,
 				C95F9FB91C03D6BC00CEA286 /* PersistentToken.swift in Sources */,
 				C9DC7EC8196BDF3B00B50C82 /* Generator.swift in Sources */,

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -1,0 +1,46 @@
+//
+//  Crypto.swift
+//  OneTimePassword
+//
+//  Copyright (c) 2016 Matt Rubin and the OneTimePassword authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import CommonCrypto
+
+// swiftlint:disable function_parameter_count
+// swiftlint:disable variable_name
+
+internal enum Crypto {
+    typealias HmacAlgorithm = UInt32
+
+    static let HmacAlgSHA1 = CCHmacAlgorithm(kCCHmacAlgSHA1)
+    static let SHA1_DIGEST_LENGTH = Int(CC_SHA1_DIGEST_LENGTH)
+
+    static let HmacAlgSHA256 = CCHmacAlgorithm(kCCHmacAlgSHA256)
+    static let SHA256_DIGEST_LENGTH = Int(CC_SHA256_DIGEST_LENGTH)
+
+    static let HmacAlgSHA512 = CCHmacAlgorithm(kCCHmacAlgSHA512)
+    static let SHA512_DIGEST_LENGTH = Int(CC_SHA512_DIGEST_LENGTH)
+
+    static func Hmac(algorithm: CCHmacAlgorithm, _ key: UnsafePointer<Void>, _ keyLength: Int, _ data: UnsafePointer<Void>, _ dataLength: Int, _ macOut: UnsafeMutablePointer<Void>) {
+        CCHmac(algorithm, key, keyLength, data, dataLength, macOut)
+    }
+}

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -31,20 +31,20 @@ import CommonCrypto
 internal enum Crypto {
     typealias HmacAlgorithm = UInt32
 
-    enum SHA1: HashFunction {
-        static let CCHmacAlgorithm = UInt32(kCCHmacAlgSHA1)
-        static let digestLength: Int = Int(CC_SHA1_DIGEST_LENGTH)
-    }
+    static let SHA1: HashFunction = _HashFunction(
+        CCHmacAlgorithm: UInt32(kCCHmacAlgSHA1),
+        digestLength: Int(CC_SHA1_DIGEST_LENGTH)
+    )
 
-    enum SHA256: HashFunction {
-        static let CCHmacAlgorithm = UInt32(kCCHmacAlgSHA256)
-        static let digestLength: Int = Int(CC_SHA256_DIGEST_LENGTH)
-    }
+    static let SHA256: HashFunction = _HashFunction(
+        CCHmacAlgorithm: UInt32(kCCHmacAlgSHA256),
+        digestLength: Int(CC_SHA256_DIGEST_LENGTH)
+    )
 
-    enum SHA512: HashFunction {
-        static let CCHmacAlgorithm = UInt32(kCCHmacAlgSHA512)
-        static let digestLength: Int = Int(CC_SHA512_DIGEST_LENGTH)
-    }
+    static let SHA512: HashFunction = _HashFunction(
+        CCHmacAlgorithm: UInt32(kCCHmacAlgSHA512),
+        digestLength: Int(CC_SHA512_DIGEST_LENGTH)
+    )
 
     static func Hmac(algorithm: CCHmacAlgorithm, _ key: UnsafePointer<Void>, _ keyLength: Int, _ data: UnsafePointer<Void>, _ dataLength: Int, _ macOut: UnsafeMutablePointer<Void>) {
         CCHmac(algorithm, key, keyLength, data, dataLength, macOut)
@@ -52,6 +52,11 @@ internal enum Crypto {
 }
 
 protocol HashFunction {
-    static var digestLength: Int { get }
-    static var CCHmacAlgorithm: UInt32 { get }
+    var digestLength: Int { get }
+    var CCHmacAlgorithm: UInt32 { get }
+}
+
+private struct _HashFunction: HashFunction {
+    let CCHmacAlgorithm: UInt32
+    let digestLength: Int
 }

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -27,32 +27,28 @@ import Foundation
 import CommonCrypto
 
 internal enum Crypto {
-    static func HMAC(hashFunction: Generator.Algorithm, key: NSData, data: NSData) -> NSData {
-        let hashLength = hashFunction.digestLength
+    static func HMAC(algorithm: Generator.Algorithm, key: NSData, data: NSData) -> NSData {
+        let (hashFunction, hashLength) = algorithm.hashInfo
 
         let macOut = UnsafeMutablePointer<UInt8>.alloc(hashLength)
         defer { macOut.dealloc(hashLength) }
 
-        CCHmac(hashFunction.ccHmacAlgorithm, key.bytes, key.length, data.bytes, data.length, macOut)
+        CCHmac(hashFunction, key.bytes, key.length, data.bytes, data.length, macOut)
 
         return NSData(bytes: macOut, length: hashLength)
     }
 }
 
 extension Generator.Algorithm {
-    private var ccHmacAlgorithm: UInt32 {
+    /// The corresponding CommonCrypto hash function and hash length.
+    private var hashInfo: (hashFunction: CCHmacAlgorithm, hashLength: Int) {
         switch self {
-        case SHA1: return UInt32(kCCHmacAlgSHA1)
-        case SHA256: return UInt32(kCCHmacAlgSHA256)
-        case SHA512: return UInt32(kCCHmacAlgSHA512)
-        }
-    }
-
-    private var digestLength: Int {
-        switch self {
-        case SHA1: return Int(CC_SHA1_DIGEST_LENGTH)
-        case SHA256: return Int(CC_SHA256_DIGEST_LENGTH)
-        case SHA512: return Int(CC_SHA512_DIGEST_LENGTH)
+        case .SHA1:
+            return (CCHmacAlgorithm(kCCHmacAlgSHA1), Int(CC_SHA1_DIGEST_LENGTH))
+        case .SHA256:
+            return (CCHmacAlgorithm(kCCHmacAlgSHA256), Int(CC_SHA256_DIGEST_LENGTH))
+        case .SHA512:
+            return (CCHmacAlgorithm(kCCHmacAlgSHA512), Int(CC_SHA512_DIGEST_LENGTH))
         }
     }
 }

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -26,17 +26,15 @@
 import Foundation
 import CommonCrypto
 
-internal enum Crypto {
-    static func HMAC(algorithm: Generator.Algorithm, key: NSData, data: NSData) -> NSData {
-        let (hashFunction, hashLength) = algorithm.hashInfo
+func HMAC(algorithm: Generator.Algorithm, key: NSData, data: NSData) -> NSData {
+    let (hashFunction, hashLength) = algorithm.hashInfo
 
-        let macOut = UnsafeMutablePointer<UInt8>.alloc(hashLength)
-        defer { macOut.dealloc(hashLength) }
+    let macOut = UnsafeMutablePointer<UInt8>.alloc(hashLength)
+    defer { macOut.dealloc(hashLength) }
 
-        CCHmac(hashFunction, key.bytes, key.length, data.bytes, data.length, macOut)
+    CCHmac(hashFunction, key.bytes, key.length, data.bytes, data.length, macOut)
 
-        return NSData(bytes: macOut, length: hashLength)
-    }
+    return NSData(bytes: macOut, length: hashLength)
 }
 
 extension Generator.Algorithm {

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -47,9 +47,9 @@ internal enum Crypto {
         digestLength: Int(CC_SHA512_DIGEST_LENGTH)
     )
 
-    static func HMAC(hashFunction: HashFunction, key: NSData, _ data: UnsafePointer<Void>, _ dataLength: Int, _ macOut: UnsafeMutablePointer<Void>) {
+    static func HMAC(hashFunction: HashFunction, key: NSData, data: NSData, _ macOut: UnsafeMutablePointer<Void>) {
         let algorithm = hashFunction.CCHmacAlgorithm
-        CCHmac(algorithm, key.bytes, key.length, data, dataLength, macOut)
+        CCHmac(algorithm, key.bytes, key.length, data.bytes, data.length, macOut)
     }
 }
 

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -27,8 +27,6 @@ import Foundation
 import CommonCrypto
 
 internal enum Crypto {
-    typealias HmacAlgorithm = UInt32
-
     static let SHA1 = HashFunction(
         ccHmacAlgorithm: UInt32(kCCHmacAlgSHA1),
         digestLength: Int(CC_SHA1_DIGEST_LENGTH)

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -27,22 +27,7 @@ import Foundation
 import CommonCrypto
 
 internal enum Crypto {
-    static let SHA1 = HashFunction(
-        ccHmacAlgorithm: UInt32(kCCHmacAlgSHA1),
-        digestLength: Int(CC_SHA1_DIGEST_LENGTH)
-    )
-
-    static let SHA256 = HashFunction(
-        ccHmacAlgorithm: UInt32(kCCHmacAlgSHA256),
-        digestLength: Int(CC_SHA256_DIGEST_LENGTH)
-    )
-
-    static let SHA512 = HashFunction(
-        ccHmacAlgorithm: UInt32(kCCHmacAlgSHA512),
-        digestLength: Int(CC_SHA512_DIGEST_LENGTH)
-    )
-
-    static func HMAC(hashFunction: HashFunction, key: NSData, data: NSData) -> NSData {
+    static func HMAC(hashFunction: Generator.Algorithm, key: NSData, data: NSData) -> NSData {
         let hashLength = hashFunction.digestLength
 
         let macOut = UnsafeMutablePointer<UInt8>.alloc(hashLength)
@@ -54,7 +39,20 @@ internal enum Crypto {
     }
 }
 
-internal struct HashFunction {
-    private let ccHmacAlgorithm: UInt32
-    internal let digestLength: Int
+extension Generator.Algorithm {
+    private var ccHmacAlgorithm: UInt32 {
+        switch self {
+        case SHA1: return UInt32(kCCHmacAlgSHA1)
+        case SHA256: return UInt32(kCCHmacAlgSHA256)
+        case SHA512: return UInt32(kCCHmacAlgSHA512)
+        }
+    }
+
+    private var digestLength: Int {
+        switch self {
+        case SHA1: return Int(CC_SHA1_DIGEST_LENGTH)
+        case SHA256: return Int(CC_SHA256_DIGEST_LENGTH)
+        case SHA512: return Int(CC_SHA512_DIGEST_LENGTH)
+        }
+    }
 }

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -47,9 +47,15 @@ internal enum Crypto {
         digestLength: Int(CC_SHA512_DIGEST_LENGTH)
     )
 
-    static func HMAC(hashFunction: HashFunction, key: NSData, data: NSData, _ macOut: UnsafeMutablePointer<Void>) {
-        let algorithm = hashFunction.CCHmacAlgorithm
-        CCHmac(algorithm, key.bytes, key.length, data.bytes, data.length, macOut)
+    static func HMAC(hashFunction: HashFunction, key: NSData, data: NSData) -> NSData {
+        let hashLength = hashFunction.digestLength
+
+        let macOut = UnsafeMutablePointer<UInt8>.alloc(hashLength)
+        defer { macOut.dealloc(hashLength) }
+
+        CCHmac(hashFunction.CCHmacAlgorithm, key.bytes, key.length, data.bytes, data.length, macOut)
+
+        return NSData(bytes: macOut, length: hashLength)
     }
 }
 

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -46,7 +46,7 @@ internal enum Crypto {
         digestLength: Int(CC_SHA512_DIGEST_LENGTH)
     )
 
-    static func Hmac(hashFunction: HashFunction, _ key: UnsafePointer<Void>, _ keyLength: Int, _ data: UnsafePointer<Void>, _ dataLength: Int, _ macOut: UnsafeMutablePointer<Void>) {
+    static func HMAC(hashFunction: HashFunction, _ key: UnsafePointer<Void>, _ keyLength: Int, _ data: UnsafePointer<Void>, _ dataLength: Int, _ macOut: UnsafeMutablePointer<Void>) {
         let algorithm = hashFunction.CCHmacAlgorithm
         CCHmac(algorithm, key, keyLength, data, dataLength, macOut)
     }

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -26,24 +26,21 @@
 import Foundation
 import CommonCrypto
 
-// swiftlint:disable function_parameter_count
-// swiftlint:disable variable_name
-
 internal enum Crypto {
     typealias HmacAlgorithm = UInt32
 
     static let SHA1 = HashFunction(
-        CCHmacAlgorithm: UInt32(kCCHmacAlgSHA1),
+        ccHmacAlgorithm: UInt32(kCCHmacAlgSHA1),
         digestLength: Int(CC_SHA1_DIGEST_LENGTH)
     )
 
     static let SHA256 = HashFunction(
-        CCHmacAlgorithm: UInt32(kCCHmacAlgSHA256),
+        ccHmacAlgorithm: UInt32(kCCHmacAlgSHA256),
         digestLength: Int(CC_SHA256_DIGEST_LENGTH)
     )
 
     static let SHA512 = HashFunction(
-        CCHmacAlgorithm: UInt32(kCCHmacAlgSHA512),
+        ccHmacAlgorithm: UInt32(kCCHmacAlgSHA512),
         digestLength: Int(CC_SHA512_DIGEST_LENGTH)
     )
 
@@ -53,13 +50,13 @@ internal enum Crypto {
         let macOut = UnsafeMutablePointer<UInt8>.alloc(hashLength)
         defer { macOut.dealloc(hashLength) }
 
-        CCHmac(hashFunction.CCHmacAlgorithm, key.bytes, key.length, data.bytes, data.length, macOut)
+        CCHmac(hashFunction.ccHmacAlgorithm, key.bytes, key.length, data.bytes, data.length, macOut)
 
         return NSData(bytes: macOut, length: hashLength)
     }
 }
 
 internal struct HashFunction {
-    private let CCHmacAlgorithm: UInt32
+    private let ccHmacAlgorithm: UInt32
     internal let digestLength: Int
 }

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -31,17 +31,17 @@ import CommonCrypto
 internal enum Crypto {
     typealias HmacAlgorithm = UInt32
 
-    static let SHA1: HashFunction = _HashFunction(
+    static let SHA1 = HashFunction(
         CCHmacAlgorithm: UInt32(kCCHmacAlgSHA1),
         digestLength: Int(CC_SHA1_DIGEST_LENGTH)
     )
 
-    static let SHA256: HashFunction = _HashFunction(
+    static let SHA256 = HashFunction(
         CCHmacAlgorithm: UInt32(kCCHmacAlgSHA256),
         digestLength: Int(CC_SHA256_DIGEST_LENGTH)
     )
 
-    static let SHA512: HashFunction = _HashFunction(
+    static let SHA512 = HashFunction(
         CCHmacAlgorithm: UInt32(kCCHmacAlgSHA512),
         digestLength: Int(CC_SHA512_DIGEST_LENGTH)
     )
@@ -52,12 +52,7 @@ internal enum Crypto {
     }
 }
 
-protocol HashFunction {
-    var digestLength: Int { get }
-    var CCHmacAlgorithm: UInt32 { get }
-}
-
-private struct _HashFunction: HashFunction {
-    let CCHmacAlgorithm: UInt32
-    let digestLength: Int
+internal struct HashFunction {
+    private let CCHmacAlgorithm: UInt32
+    internal let digestLength: Int
 }

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -31,16 +31,27 @@ import CommonCrypto
 internal enum Crypto {
     typealias HmacAlgorithm = UInt32
 
-    static let HmacAlgSHA1 = CCHmacAlgorithm(kCCHmacAlgSHA1)
-    static let SHA1_DIGEST_LENGTH = Int(CC_SHA1_DIGEST_LENGTH)
+    enum SHA1: HashFunction {
+        static let CCHmacAlgorithm = UInt32(kCCHmacAlgSHA1)
+        static let digestLength: Int = Int(CC_SHA1_DIGEST_LENGTH)
+    }
 
-    static let HmacAlgSHA256 = CCHmacAlgorithm(kCCHmacAlgSHA256)
-    static let SHA256_DIGEST_LENGTH = Int(CC_SHA256_DIGEST_LENGTH)
+    enum SHA256: HashFunction {
+        static let CCHmacAlgorithm = UInt32(kCCHmacAlgSHA256)
+        static let digestLength: Int = Int(CC_SHA256_DIGEST_LENGTH)
+    }
 
-    static let HmacAlgSHA512 = CCHmacAlgorithm(kCCHmacAlgSHA512)
-    static let SHA512_DIGEST_LENGTH = Int(CC_SHA512_DIGEST_LENGTH)
+    enum SHA512: HashFunction {
+        static let CCHmacAlgorithm = UInt32(kCCHmacAlgSHA512)
+        static let digestLength: Int = Int(CC_SHA512_DIGEST_LENGTH)
+    }
 
     static func Hmac(algorithm: CCHmacAlgorithm, _ key: UnsafePointer<Void>, _ keyLength: Int, _ data: UnsafePointer<Void>, _ dataLength: Int, _ macOut: UnsafeMutablePointer<Void>) {
         CCHmac(algorithm, key, keyLength, data, dataLength, macOut)
     }
+}
+
+protocol HashFunction {
+    static var digestLength: Int { get }
+    static var CCHmacAlgorithm: UInt32 { get }
 }

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -23,6 +23,7 @@
 //  SOFTWARE.
 //
 
+import Foundation
 import CommonCrypto
 
 // swiftlint:disable function_parameter_count
@@ -46,9 +47,9 @@ internal enum Crypto {
         digestLength: Int(CC_SHA512_DIGEST_LENGTH)
     )
 
-    static func HMAC(hashFunction: HashFunction, _ key: UnsafePointer<Void>, _ keyLength: Int, _ data: UnsafePointer<Void>, _ dataLength: Int, _ macOut: UnsafeMutablePointer<Void>) {
+    static func HMAC(hashFunction: HashFunction, key: NSData, _ data: UnsafePointer<Void>, _ dataLength: Int, _ macOut: UnsafeMutablePointer<Void>) {
         let algorithm = hashFunction.CCHmacAlgorithm
-        CCHmac(algorithm, key, keyLength, data, dataLength, macOut)
+        CCHmac(algorithm, key.bytes, key.length, data, dataLength, macOut)
     }
 }
 

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -46,7 +46,8 @@ internal enum Crypto {
         digestLength: Int(CC_SHA512_DIGEST_LENGTH)
     )
 
-    static func Hmac(algorithm: CCHmacAlgorithm, _ key: UnsafePointer<Void>, _ keyLength: Int, _ data: UnsafePointer<Void>, _ dataLength: Int, _ macOut: UnsafeMutablePointer<Void>) {
+    static func Hmac(hashFunction: HashFunction, _ key: UnsafePointer<Void>, _ keyLength: Int, _ data: UnsafePointer<Void>, _ dataLength: Int, _ macOut: UnsafeMutablePointer<Void>) {
+        let algorithm = hashFunction.CCHmacAlgorithm
         CCHmac(algorithm, key, keyLength, data, dataLength, macOut)
     }
 }

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -81,7 +81,7 @@ public struct Generator: Equatable {
         let hashLength = algorithm.hashFunction.digestLength
         let hashPointer = UnsafeMutablePointer<UInt8>.alloc(hashLength)
         defer { hashPointer.dealloc(hashLength) }
-        Crypto.HMAC(algorithm.hashFunction, secret.bytes, secret.length, &bigCounter, sizeof(UInt64), hashPointer)
+        Crypto.HMAC(algorithm.hashFunction, key: secret, &bigCounter, sizeof(UInt64), hashPointer)
 
         // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
         let ptr = UnsafePointer<UInt8>(hashPointer)

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import CommonCrypto
 
 /// A `Generator` contains all of the parameters needed to generate a one-time password.
 public struct Generator: Equatable {
@@ -82,7 +81,7 @@ public struct Generator: Equatable {
         let (hashAlgorithm, hashLength) = algorithm.hashInfo
         let hashPointer = UnsafeMutablePointer<UInt8>.alloc(hashLength)
         defer { hashPointer.dealloc(hashLength) }
-        CCHmac(hashAlgorithm, secret.bytes, secret.length, &bigCounter, sizeof(UInt64), hashPointer)
+        Crypto.Hmac(hashAlgorithm, secret.bytes, secret.length, &bigCounter, sizeof(UInt64), hashPointer)
 
         // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
         let ptr = UnsafePointer<UInt8>(hashPointer)
@@ -178,14 +177,14 @@ public struct Generator: Equatable {
         case SHA512
 
         /// The corresponding CommonCrypto hash algorithm and hash length.
-        private var hashInfo: (algorithm: CCHmacAlgorithm, length: Int) {
+        private var hashInfo: (algorithm: Crypto.HmacAlgorithm, length: Int) {
             switch self {
             case .SHA1:
-                return (CCHmacAlgorithm(kCCHmacAlgSHA1), Int(CC_SHA1_DIGEST_LENGTH))
+                return (Crypto.HmacAlgSHA1, Crypto.SHA1_DIGEST_LENGTH)
             case .SHA256:
-                return (CCHmacAlgorithm(kCCHmacAlgSHA256), Int(CC_SHA256_DIGEST_LENGTH))
+                return (Crypto.HmacAlgSHA256, Crypto.SHA256_DIGEST_LENGTH)
             case .SHA512:
-                return (CCHmacAlgorithm(kCCHmacAlgSHA512), Int(CC_SHA512_DIGEST_LENGTH))
+                return (Crypto.HmacAlgSHA512, Crypto.SHA512_DIGEST_LENGTH)
             }
         }
     }

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -78,10 +78,10 @@ public struct Generator: Equatable {
         var bigCounter = counter.bigEndian
 
         // Generate an HMAC value from the key and counter
-        let (hashAlgorithm, hashLength) = algorithm.hashInfo
+        let hashLength = algorithm.hashFunction.digestLength
         let hashPointer = UnsafeMutablePointer<UInt8>.alloc(hashLength)
         defer { hashPointer.dealloc(hashLength) }
-        Crypto.Hmac(hashAlgorithm, secret.bytes, secret.length, &bigCounter, sizeof(UInt64), hashPointer)
+        Crypto.Hmac(algorithm.hashFunction, secret.bytes, secret.length, &bigCounter, sizeof(UInt64), hashPointer)
 
         // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
         let ptr = UnsafePointer<UInt8>(hashPointer)
@@ -177,14 +177,14 @@ public struct Generator: Equatable {
         case SHA512
 
         /// The corresponding CommonCrypto hash algorithm and hash length.
-        private var hashInfo: (algorithm: Crypto.HmacAlgorithm, length: Int) {
+        private var hashFunction: HashFunction {
             switch self {
             case .SHA1:
-                return (Crypto.SHA1.CCHmacAlgorithm, Crypto.SHA1.digestLength)
+                return Crypto.SHA1
             case .SHA256:
-                return (Crypto.SHA256.CCHmacAlgorithm, Crypto.SHA256.digestLength)
+                return Crypto.SHA256
             case .SHA512:
-                return (Crypto.SHA512.CCHmacAlgorithm, Crypto.SHA512.digestLength)
+                return Crypto.SHA512
             }
         }
     }

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -78,15 +78,12 @@ public struct Generator: Equatable {
         var bigCounter = counter.bigEndian
 
         // Generate an HMAC value from the key and counter
-        let hashLength = algorithm.hashFunction.digestLength
-        let hashPointer = UnsafeMutablePointer<UInt8>.alloc(hashLength)
-        defer { hashPointer.dealloc(hashLength) }
         let counterData = NSData(bytes: &bigCounter, length: sizeof(UInt64))
-        Crypto.HMAC(algorithm.hashFunction, key: secret, data: counterData, hashPointer)
+        let hash = Crypto.HMAC(algorithm.hashFunction, key: secret, data: counterData)
 
         // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
-        let ptr = UnsafePointer<UInt8>(hashPointer)
-        let offset = ptr[hashLength-1] & 0x0f
+        let ptr = UnsafePointer<UInt8>(hash.bytes)
+        let offset = ptr[hash.length-1] & 0x0f
 
         // Take 4 bytes from the hash, starting at the given byte offset
         let truncatedHashPtr = ptr + Int(offset)

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -79,7 +79,7 @@ public struct Generator: Equatable {
 
         // Generate an HMAC value from the key and counter
         let counterData = NSData(bytes: &bigCounter, length: sizeof(UInt64))
-        let hash = Crypto.HMAC(algorithm, key: secret, data: counterData)
+        let hash = HMAC(algorithm, key: secret, data: counterData)
 
         // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
         let ptr = UnsafePointer<UInt8>(hash.bytes)

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -79,7 +79,7 @@ public struct Generator: Equatable {
 
         // Generate an HMAC value from the key and counter
         let counterData = NSData(bytes: &bigCounter, length: sizeof(UInt64))
-        let hash = Crypto.HMAC(algorithm.hashFunction, key: secret, data: counterData)
+        let hash = Crypto.HMAC(algorithm, key: secret, data: counterData)
 
         // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
         let ptr = UnsafePointer<UInt8>(hash.bytes)
@@ -173,18 +173,6 @@ public struct Generator: Equatable {
         case SHA256
         /// The SHA-512 hash function
         case SHA512
-
-        /// The corresponding CommonCrypto hash algorithm and hash length.
-        private var hashFunction: HashFunction {
-            switch self {
-            case .SHA1:
-                return Crypto.SHA1
-            case .SHA256:
-                return Crypto.SHA256
-            case .SHA512:
-                return Crypto.SHA512
-            }
-        }
     }
 
     /// An error type enum representing the various errors a `Generator` can throw when computing a

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -180,11 +180,11 @@ public struct Generator: Equatable {
         private var hashInfo: (algorithm: Crypto.HmacAlgorithm, length: Int) {
             switch self {
             case .SHA1:
-                return (Crypto.HmacAlgSHA1, Crypto.SHA1_DIGEST_LENGTH)
+                return (Crypto.SHA1.CCHmacAlgorithm, Crypto.SHA1.digestLength)
             case .SHA256:
-                return (Crypto.HmacAlgSHA256, Crypto.SHA256_DIGEST_LENGTH)
+                return (Crypto.SHA256.CCHmacAlgorithm, Crypto.SHA256.digestLength)
             case .SHA512:
-                return (Crypto.HmacAlgSHA512, Crypto.SHA512_DIGEST_LENGTH)
+                return (Crypto.SHA512.CCHmacAlgorithm, Crypto.SHA512.digestLength)
             }
         }
     }

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -81,7 +81,8 @@ public struct Generator: Equatable {
         let hashLength = algorithm.hashFunction.digestLength
         let hashPointer = UnsafeMutablePointer<UInt8>.alloc(hashLength)
         defer { hashPointer.dealloc(hashLength) }
-        Crypto.HMAC(algorithm.hashFunction, key: secret, &bigCounter, sizeof(UInt64), hashPointer)
+        let counterData = NSData(bytes: &bigCounter, length: sizeof(UInt64))
+        Crypto.HMAC(algorithm.hashFunction, key: secret, data: counterData, hashPointer)
 
         // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
         let ptr = UnsafePointer<UInt8>(hashPointer)

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -81,7 +81,7 @@ public struct Generator: Equatable {
         let hashLength = algorithm.hashFunction.digestLength
         let hashPointer = UnsafeMutablePointer<UInt8>.alloc(hashLength)
         defer { hashPointer.dealloc(hashLength) }
-        Crypto.Hmac(algorithm.hashFunction, secret.bytes, secret.length, &bigCounter, sizeof(UInt64), hashPointer)
+        Crypto.HMAC(algorithm.hashFunction, secret.bytes, secret.length, &bigCounter, sizeof(UInt64), hashPointer)
 
         // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
         let ptr = UnsafePointer<UInt8>(hashPointer)


### PR DESCRIPTION
Isolate the CommonCrypto dependency inside a custom wrapper function, in preparation for replacing it with a different HMAC implementation.