### PR TITLE
Swift 3 Test Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ language: objective-c
 xcode_workspace: OneTimePassword.xcworkspace
 xcode_scheme: OneTimePassword
 
-osx_image: xcode7.2
-xcode_sdk: iphonesimulator9.2
+osx_image: xcode7.3
+xcode_sdk: iphonesimulator9.3
 
 env:
   - DESTINATION="OS=8.1,name=iPhone 4S"
@@ -16,6 +16,13 @@ env:
   - DESTINATION="OS=9.0,name=iPhone 6 Plus"
   - DESTINATION="OS=9.1,name=iPhone 6S"
   - DESTINATION="OS=9.2,name=iPhone 6S Plus"
+  - DESTINATION="OS=9.3,name=iPhone 6S Plus"
+
+matrix:
+  include:
+    - osx_image: xcode8
+      xcode_sdk: iphonesimulator10.0
+      env: DESTINATION="OS=10.0,name=iPhone SE"
 
 # Check out nested dependencies
 before_install: git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,15 @@ language: objective-c
 xcode_workspace: OneTimePassword.xcworkspace
 xcode_scheme: OneTimePassword
 
-osx_image: xcode7.3
-xcode_sdk: iphonesimulator9.3
+osx_image: xcode8
+xcode_sdk: iphonesimulator10.0
 
 env:
-  - DESTINATION="OS=8.1,name=iPhone 4S"
-  - DESTINATION="OS=8.2,name=iPhone 5"
-  - DESTINATION="OS=8.3,name=iPhone 5S"
-  - DESTINATION="OS=8.4,name=iPhone 6"
-  - DESTINATION="OS=9.0,name=iPhone 6 Plus"
-  - DESTINATION="OS=9.1,name=iPhone 6S"
-  - DESTINATION="OS=9.2,name=iPhone 6S Plus"
-  - DESTINATION="OS=9.3,name=iPhone 6S Plus"
-
-matrix:
-  include:
-    - osx_image: xcode8
-      xcode_sdk: iphonesimulator10.0
-      env: DESTINATION="OS=10.0,name=iPhone SE"
+  - DESTINATION="OS=10.0,name=iPhone 4S"
+  - DESTINATION="OS=10.0,name=iPhone 6S Plus"
+  - DESTINATION="OS=10.0,name=iPhone SE"
+  - DESTINATION="OS=10.0,name=iPad Retina"
+  - DESTINATION="OS=10.0,name=iPad Pro (12.9-inch)"
 
 # Check out nested dependencies
 before_install: git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - DESTINATION="OS=10.0,name=iPhone 6S Plus"
   - DESTINATION="OS=10.0,name=iPhone SE"
   - DESTINATION="OS=10.0,name=iPad Retina"
-  - DESTINATION="OS=10.0,name=iPad Pro (12.9-inch)"
+  - DESTINATION="OS=10.0,name=iPad Pro (12.9 inch)"
 
 # Check out nested dependencies
 before_install: git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ osx_image: xcode8
 xcode_sdk: iphonesimulator10.0
 
 env:
-  - DESTINATION="OS=10.0,name=iPhone 4S"
+  - DESTINATION="OS=10.0,name=iPhone 5"
   - DESTINATION="OS=10.0,name=iPhone 6S Plus"
   - DESTINATION="OS=10.0,name=iPhone SE"
   - DESTINATION="OS=10.0,name=iPad Retina"

--- a/Tests/KeychainTests.swift
+++ b/Tests/KeychainTests.swift
@@ -23,6 +23,12 @@
 //  SOFTWARE.
 //
 
+// NOTE: Keychain access seems to be broken (error -34018) as of Xcode 8 beta 2.
+// https://forums.developer.apple.com/thread/51071
+// The current workaround for this issue is to enable the keychain sharing entitlement, but since
+// entitlements appear to not affect test bundles, there isn't a fix for broken keychain tests.
+// Until a future beta fixes the issue, keychain tests are disabled for iOS 10.
+
 import XCTest
 import OneTimePassword
 
@@ -41,6 +47,9 @@ class KeychainTests: XCTestCase {
     let keychain = Keychain.sharedInstance
 
     func testPersistentTokenWithIdentifier() {
+        // See the NOTE above
+        if #available(iOS 10, *) { return }
+
         // Create a token
         let token = testToken
 
@@ -100,6 +109,9 @@ class KeychainTests: XCTestCase {
     }
 
     func testDuplicateTokens() {
+        // See the NOTE above
+        if #available(iOS 10, *) { return }
+
         let token1 = testToken, token2 = testToken
 
         do {
@@ -172,6 +184,9 @@ class KeychainTests: XCTestCase {
     }
 
     func testAllPersistentTokens() {
+        // See the NOTE above
+        if #available(iOS 10, *) { return }
+
         let token1 = testToken, token2 = testToken, token3 = testToken
 
         do {


### PR DESCRIPTION
Merge the keychain test workaround from `master` and update the Travis config to build with Xcode 8 only.