### PR TITLE
Whitespace

### DIFF
--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -27,7 +27,6 @@ import Foundation
 
 /// A `Generator` contains all of the parameters needed to generate a one-time password.
 public struct Generator: Equatable {
-
     /// The moving factor, either timer- or counter-based.
     public let factor: Factor
 

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -128,7 +128,7 @@ private extension Token {
 private extension PersistentToken {
     private init?(keychainDictionary: NSDictionary) {
         guard let urlData = keychainDictionary[kSecAttrGeneric as String] as? NSData,
-            let string = NSString(data: urlData, encoding:NSUTF8StringEncoding),
+            let string = NSString(data: urlData, encoding: NSUTF8StringEncoding),
             let secret = keychainDictionary[kSecValueData as String] as? NSData,
             let keychainItemRef = keychainDictionary[kSecValuePersistentRef as String] as? NSData,
             let url = NSURL(string: string as String),

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -95,18 +95,18 @@ private func urlForToken(name name: String, issuer: String, factor: Generator.Fa
     urlComponents.path = "/" + name
 
     var queryItems = [
-        NSURLQueryItem(name:kQueryAlgorithmKey, value:stringForAlgorithm(algorithm)),
-        NSURLQueryItem(name:kQueryDigitsKey, value:String(digits)),
-        NSURLQueryItem(name:kQueryIssuerKey, value:issuer)
+        NSURLQueryItem(name: kQueryAlgorithmKey, value: stringForAlgorithm(algorithm)),
+        NSURLQueryItem(name: kQueryDigitsKey, value: String(digits)),
+        NSURLQueryItem(name: kQueryIssuerKey, value: issuer)
     ]
 
     switch factor {
     case .Timer(let period):
         urlComponents.host = kFactorTimerKey
-        queryItems.append(NSURLQueryItem(name:kQueryPeriodKey, value:String(Int(period))))
+        queryItems.append(NSURLQueryItem(name: kQueryPeriodKey, value: String(Int(period))))
     case .Counter(let counter):
         urlComponents.host = kFactorCounterKey
-        queryItems.append(NSURLQueryItem(name:kQueryCounterKey, value:String(counter)))
+        queryItems.append(NSURLQueryItem(name: kQueryCounterKey, value: String(counter)))
     }
 
     urlComponents.queryItems = queryItems

--- a/Sources/Token.swift
+++ b/Sources/Token.swift
@@ -27,7 +27,6 @@ import Foundation
 
 /// A `Token` contains a password generator and information identifying the corresponding account.
 public struct Token: Equatable {
-
     /// A string indicating the account represented by the token.
     /// This is often an email address or username.
     public let name: String

--- a/Tests/TokenSerializationTests.swift
+++ b/Tests/TokenSerializationTests.swift
@@ -83,7 +83,7 @@ class TokenSerializationTests: XCTestCase {
                                 // Test name
                                 XCTAssertEqual(url.path!.substringFromIndex(url.path!.startIndex.successor()), name, "The url path should be \"\(name)\"")
 
-                                let urlComponents = NSURLComponents(URL:url, resolvingAgainstBaseURL:false)
+                                let urlComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)
                                 let items = urlComponents?.queryItems
                                 let expectedItemCount = 4
                                 XCTAssertEqual(items?.count, expectedItemCount, "There shouldn't be any unexpected query arguments: \(url)")


### PR DESCRIPTION
Add spaces between parameter names and arguments and remove extra newlines at the beginning of types.