### PR TITLE
Update Travis configuration to use Xcode 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   - DESTINATION="OS=9.2,name=iPhone 6S Plus"
   - DESTINATION="OS=9.3,name=iPhone 6S Plus"
   - DESTINATION="OS=10.0,name=iPhone 7"
-  - DESTINATION="OS=10.0,name=iPhone 7 Plus"
-  - DESTINATION="OS=10.0,name=iPhone SE"
+#  - DESTINATION="OS=10.0,name=iPhone 7 Plus"
+#  - DESTINATION="OS=10.0,name=iPhone SE"
 
 # For now, continue testing with Xcode 7.3 and Swift 2.2
 # Testing on iOS 8.x currently times out on Travis with Xcode 8:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ language: objective-c
 xcode_workspace: OneTimePassword.xcworkspace
 xcode_scheme: OneTimePassword
 
-osx_image: xcode7.3
-xcode_sdk: iphonesimulator9.3
+osx_image: xcode8
+xcode_sdk: iphonesimulator10.0
 
 env:
   - DESTINATION="OS=8.1,name=iPhone 4S"
@@ -17,12 +17,16 @@ env:
   - DESTINATION="OS=9.1,name=iPhone 6S"
   - DESTINATION="OS=9.2,name=iPhone 6S Plus"
   - DESTINATION="OS=9.3,name=iPhone 6S Plus"
+  - DESTINATION="OS=10.0,name=iPhone 7"
+  - DESTINATION="OS=10.0,name=iPhone 7 Plus"
+  - DESTINATION="OS=10.0,name=iPhone SE"
 
+# For now, continue testing with Xcode 7.3 and Swift 2.2
 matrix:
   include:
-    - osx_image: xcode8
-      xcode_sdk: iphonesimulator10.0
-      env: DESTINATION="OS=10.0,name=iPhone SE"
+    - osx_image: xcode7.3
+      xcode_sdk: iphonesimulator9.3
+      env: DESTINATION="OS=8.1,name=iPhone 4S"
 
 # Check out nested dependencies
 before_install: git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ osx_image: xcode8
 xcode_sdk: iphonesimulator10.0
 
 env:
-  - DESTINATION="OS=8.1,name=iPhone 4S"
-  - DESTINATION="OS=8.2,name=iPhone 5"
-  - DESTINATION="OS=8.3,name=iPhone 5S"
-  - DESTINATION="OS=8.4,name=iPhone 6"
   - DESTINATION="OS=9.0,name=iPhone 6 Plus"
   - DESTINATION="OS=9.1,name=iPhone 6S"
   - DESTINATION="OS=9.2,name=iPhone 6S Plus"
@@ -22,11 +18,22 @@ env:
   - DESTINATION="OS=10.0,name=iPhone SE"
 
 # For now, continue testing with Xcode 7.3 and Swift 2.2
+# Testing on iOS 8.x currently times out on Travis with Xcode 8:
+# https://travis-ci.org/mattrubin/OneTimePassword/jobs/160929197
 matrix:
   include:
     - osx_image: xcode7.3
       xcode_sdk: iphonesimulator9.3
       env: DESTINATION="OS=8.1,name=iPhone 4S"
+    - osx_image: xcode7.3
+      xcode_sdk: iphonesimulator9.3
+      env: DESTINATION="OS=8.2,name=iPhone 5"
+    - osx_image: xcode7.3
+      xcode_sdk: iphonesimulator9.3
+      env: DESTINATION="OS=8.3,name=iPhone 5S"
+    - osx_image: xcode7.3
+      xcode_sdk: iphonesimulator9.3
+      env: DESTINATION="OS=8.4,name=iPhone 6"
 
 # Check out nested dependencies
 before_install: git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,11 @@ osx_image: xcode8
 xcode_sdk: iphonesimulator10.0
 
 env:
-  - DESTINATION="OS=9.0,name=iPhone 6 Plus"
-  - DESTINATION="OS=9.1,name=iPhone 6S"
-  - DESTINATION="OS=9.2,name=iPhone 6S Plus"
+  - DESTINATION="OS=9.0,name=iPhone 6"
+  - DESTINATION="OS=9.1,name=iPhone 6 Plus"
+  - DESTINATION="OS=9.2,name=iPhone 6S"
   - DESTINATION="OS=9.3,name=iPhone 6S Plus"
   - DESTINATION="OS=10.0,name=iPhone 7"
-#  - DESTINATION="OS=10.0,name=iPhone 7 Plus"
-#  - DESTINATION="OS=10.0,name=iPhone SE"
 
 # For now, continue testing with Xcode 7.3 and Swift 2.2
 # Testing on iOS 8.x currently times out on Travis with Xcode 8:


### PR DESCRIPTION
Default to using Xcode 8 for Travis builds.

Testing on iOS 8.x currently times out on Travis with Xcode 8, so those tests will remain on Xcode 7.3. This is also useful for ensuring continued support for building with Swift 2.2.