### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [In development][master]
 #### Enhancements
-- Add watchOS target ([#96](https://github.com/mattrubin/OneTimePassword/pull/96))
+- Add watchOS support ([#96](https://github.com/mattrubin/OneTimePassword/pull/96), [#98](https://github.com/mattrubin/OneTimePassword/pull/98))
 
 #### Other Changes
 - Clean up project configuration and build settings ([#95](https://github.com/mattrubin/OneTimePassword/pull/95), [#97](https://github.com/mattrubin/OneTimePassword/pull/97))

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 # Configuration for Carthage (https://github.com/Carthage/Carthage)
 
-github "mattrubin/Base32" "develop"
+github "mattrubin/Base32" "1.1.2+carthage"

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 # Configuration for Carthage (https://github.com/Carthage/Carthage)
 
-github "jspahrsummers/xcconfigs" >= 0.9
+github "jspahrsummers/xcconfigs" ~> 0.10

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "mattrubin/Base32" "10a158018d4fa83cdbde9eb882654745dfe43835"
+github "mattrubin/Base32" "1.1.2+carthage"
 github "jspahrsummers/xcconfigs" "0.10"


### PR DESCRIPTION
Update Base32 to the latest *release* version – which adds watchOS support – and bump the version constraint of the xcconfigs dependency.