### PR TITLE
Improve Xcode path injection

### DIFF
--- a/OneTimePassword.podspec
+++ b/OneTimePassword.podspec
@@ -20,5 +20,10 @@ Pod::Spec.new do |s|
     "SWIFT_INCLUDE_PATHS[sdk=watchsimulator*]"    => "$(SRCROOT)/OneTimePassword/CommonCrypto/watchsimulator",
   }
   s.preserve_paths = "CommonCrypto/*"
+  # The prepare_command "will be executed after the Pod is downloaded."
+  # The script is *not* run on every build, or even on every `pod install`, so if the selected
+  # Xcode path changes after the pod is downloaded, you may need to clear the pod from the cache at
+  # ~/Library/Caches/CocoaPods so the script can update the modulemaps with the new path.
+  # https://guides.cocoapods.org/syntax/podspec.html#prepare_command
   s.prepare_command = "CommonCrypto/injectXcodePath.sh"
 end

--- a/OneTimePassword.xcodeproj/project.pbxproj
+++ b/OneTimePassword.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		FDD3B8661DD6E59E00F87980 /* CommonCrypto */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = FDD3B8671DD6E59E00F87980 /* Build configuration list for PBXAggregateTarget "CommonCrypto" */;
+			buildPhases = (
+				FDD3B86A1DD6E5B700F87980 /* Inject Xcode Path */,
+			);
+			dependencies = (
+			);
+			name = CommonCrypto;
+			productName = CommonCrypto;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		5B39F49C1DBD06EB00CD2DAB /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93A2519196B1BA400F86892 /* Token.swift */; };
 		5B39F49D1DBD06EE00CD2DAB /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DC7EC7196BDF3B00B50C82 /* Generator.swift */; };
@@ -50,6 +64,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = C97C82371946E51D00FD9F4C;
 			remoteInfo = "OneTimePassword (iOS)";
+		};
+		FD61F4741DD6E73200166DD9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C97C822F1946E51D00FD9F4C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FDD3B8661DD6E59E00F87980;
+			remoteInfo = CommonCrypto;
+		};
+		FDA822711DD6E69F005E4127 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C97C822F1946E51D00FD9F4C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FDD3B8661DD6E59E00F87980;
+			remoteInfo = CommonCrypto;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -354,6 +382,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				FDA822721DD6E69F005E4127 /* PBXTargetDependency */,
 			);
 			name = "OneTimePassword (watchOS)";
 			productName = "OneTimePassword (watchOS)";
@@ -364,7 +393,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C97C824E1946E51D00FD9F4C /* Build configuration list for PBXNativeTarget "OneTimePassword (iOS)" */;
 			buildPhases = (
-				FD0180951DD6C78A0088E484 /* Inject Xcode Path */,
 				C97C82331946E51D00FD9F4C /* Sources */,
 				C97CDF2E1BEFB20000D64406 /* Lint */,
 				C97C82341946E51D00FD9F4C /* Frameworks */,
@@ -373,6 +401,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				FD61F4751DD6E73200166DD9 /* PBXTargetDependency */,
 			);
 			name = "OneTimePassword (iOS)";
 			productName = "OneTimePassword (iOS)";
@@ -443,6 +472,10 @@
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Manual;
 					};
+					FDD3B8661DD6E59E00F87980 = {
+						CreatedOnToolsVersion = 8.1;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = C97C82321946E51D00FD9F4C /* Build configuration list for PBXProject "OneTimePassword" */;
@@ -457,6 +490,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				FDD3B8661DD6E59E00F87980 /* CommonCrypto */,
 				C97C82371946E51D00FD9F4C /* OneTimePassword (iOS) */,
 				C97C82421946E51D00FD9F4C /* OneTimePasswordTests */,
 				C9A486B2196F352E00524F51 /* OneTimePasswordLegacyTests */,
@@ -480,7 +514,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
-		FD0180951DD6C78A0088E484 /* Inject Xcode Path */ = {
+		FDD3B86A1DD6E5B700F87980 /* Inject Xcode Path */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -558,6 +592,16 @@
 			isa = PBXTargetDependency;
 			target = C97C82371946E51D00FD9F4C /* OneTimePassword (iOS) */;
 			targetProxy = C97C82451946E51D00FD9F4C /* PBXContainerItemProxy */;
+		};
+		FD61F4751DD6E73200166DD9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FDD3B8661DD6E59E00F87980 /* CommonCrypto */;
+			targetProxy = FD61F4741DD6E73200166DD9 /* PBXContainerItemProxy */;
+		};
+		FDA822721DD6E69F005E4127 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FDD3B8661DD6E59E00F87980 /* CommonCrypto */;
+			targetProxy = FDA822711DD6E69F005E4127 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -644,6 +688,20 @@
 			};
 			name = Release;
 		};
+		FDD3B8681DD6E59E00F87980 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		FDD3B8691DD6E59E00F87980 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -688,6 +746,15 @@
 			buildConfigurations = (
 				C9A486BE196F352F00524F51 /* Debug */,
 				C9A486BF196F352F00524F51 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FDD3B8671DD6E59E00F87980 /* Build configuration list for PBXAggregateTarget "CommonCrypto" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FDD3B8681DD6E59E00F87980 /* Debug */,
+				FDD3B8691DD6E59E00F87980 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
 - Add a dependency target to all framework targets which injects the Xcode path
 - Add a comment explaining the limitations of the pod's `prepare_command`