### PR TITLE
Easier new clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Other Changes
 - Clean up project configuration and build settings. ([#95](https://github.com/mattrubin/OneTimePassword/pull/95), [#97](https://github.com/mattrubin/OneTimePassword/pull/97))
+- Improve instructions and project settings to make setting up a new clone easier. ([#104](https://github.com/mattrubin/OneTimePassword/pull/104))
 
 
 ## [2.0.1][] (2016-09-20)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,9 @@ Please note that this project is released with a [Contributor Code of Conduct][c
   git clone https://github.com/mattrubin/OneTimePassword.git
   ```
 
-2. Check out the project's dependencies:
+2. In the OneTimePassword directory, check out the project's dependencies:
   ```
+  cd OneTimePassword
   git submodule update --init --recursive
   ```
 

--- a/OneTimePassword.xcodeproj/project.pbxproj
+++ b/OneTimePassword.xcodeproj/project.pbxproj
@@ -220,7 +220,9 @@
 				C9B84D1B1C015EA2002EE631 /* Tools */,
 				C94B9BC71BD726F70073D7C5 /* Docs */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		C97C82391946E51D00FD9F4C /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Improve the "Getting Started" instructions and add project-wide indentation configuration to the Xcode project.