### PR TITLE
Add tests for validation and parsing failures

### DIFF
--- a/OneTimePasswordLegacyTests/OTPTokenSerializationTests.m
+++ b/OneTimePasswordLegacyTests/OTPTokenSerializationTests.m
@@ -374,8 +374,12 @@ static const unsigned char kValidSecret[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05
                          @"otpauth://foo", // invalid type
                          @"otpauth://totp/bar", // missing secret
                          @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&period=0", // invalid period
+                         @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&period=x", // non-numeric period
                          @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&algorithm=MD5", // invalid algorithm
                          @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&digits=2", // invalid digits
+                         @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&digits=x", // non-numeric digits
+                         @"otpauth://hotp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&counter=1.5", // invalid counter
+                         @"otpauth://hotp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&counter=x", // non-numeric counter
                          ];
 
     for (NSString *badURL in badURLs) {

--- a/OneTimePasswordLegacyTests/OTPTokenSerializationTests.m
+++ b/OneTimePasswordLegacyTests/OTPTokenSerializationTests.m
@@ -2,7 +2,7 @@
 //  OTPTokenSerializationTests.m
 //  OneTimePassword
 //
-//  Copyright (c) 2013-2015 Matt Rubin and the OneTimePassword authors
+//  Copyright (c) 2013-2016 Matt Rubin and the OneTimePassword authors
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -131,9 +131,7 @@ private func tokenFromURL(url: NSURL, secret externalSecret: NSData? = nil) -> T
         if string == kFactorCounterKey {
             if let counter: UInt64 = parse(queryDictionary[kQueryCounterKey],
                 with: {
-                    errno = 0
-                    let counterValue = strtoull(($0 as NSString).UTF8String, nil, 10)
-                    guard errno == 0 else {
+                    guard let counterValue = UInt64($0, radix: 10) else {
                         return nil
                     }
                     return counterValue

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -2,7 +2,7 @@
 //  GeneratorTests.swift
 //  OneTimePassword
 //
-//  Copyright (c) 2014-2015 Matt Rubin and the OneTimePassword authors
+//  Copyright (c) 2014-2016 Matt Rubin and the OneTimePassword authors
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -172,6 +172,22 @@ class GeneratorTests: XCTestCase {
         XCTFail("passwordAtTime(\(badTime)) should throw an error)")
     }
 
+    func testPasswordWithInvalidPeriod() {
+        let generator = Generator(unvalidatedFactor: .Timer(period: 0))
+        let time: NSTimeInterval = 100
+
+        do {
+            _ = try generator.passwordAtTime(time)
+        } catch Generator.Error.InvalidPeriod {
+            // This is the expected type of error
+            return
+        } catch {
+            XCTFail("passwordAtTime(\(time)) threw an unexpected type of error: \(error))")
+            return
+        }
+        XCTFail("passwordAtTime(\(time)) should throw an error)")
+    }
+
     // The values in this test are found in Appendix D of the HOTP RFC
     // https://tools.ietf.org/html/rfc4226#appendix-D
     func testHOTPRFCValues() {
@@ -247,5 +263,17 @@ class GeneratorTests: XCTestCase {
                     "Incorrect result for \(algorithm) at \(times[i])")
             }
         }
+    }
+}
+
+private extension Generator {
+    init(unvalidatedFactor factor: Factor = .Timer(period: 30),
+         unvalidatedSecret secret: NSData = NSData(),
+         unvalidatedAlgorithm algorithm: Algorithm = .SHA1,
+         unvalidatedDigits digits: Int = 8) {
+        self.factor = factor
+        self.secret = secret
+        self.algorithm = algorithm
+        self.digits = digits
     }
 }

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -188,6 +188,22 @@ class GeneratorTests: XCTestCase {
         XCTFail("passwordAtTime(\(time)) should throw an error)")
     }
 
+    func testPasswordWithInvalidDigits() {
+        let generator = Generator(unvalidatedDigits: 3)
+        let time: NSTimeInterval = 100
+
+        do {
+            _ = try generator.passwordAtTime(time)
+        } catch Generator.Error.InvalidDigits {
+            // This is the expected type of error
+            return
+        } catch {
+            XCTFail("passwordAtTime(\(time)) threw an unexpected type of error: \(error))")
+            return
+        }
+        XCTFail("passwordAtTime(\(time)) should throw an error)")
+    }
+
     // The values in this test are found in Appendix D of the HOTP RFC
     // https://tools.ietf.org/html/rfc4226#appendix-D
     func testHOTPRFCValues() {

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -148,6 +148,30 @@ class GeneratorTests: XCTestCase {
         }
     }
 
+    func testPasswordAtInvalidTime() {
+        guard let generator = Generator(
+            factor: .Timer(period: 30),
+            secret: NSData(),
+            algorithm: .SHA1,
+            digits: 6
+            ) else {
+                XCTFail("Failed to initialize a Generator.")
+                return
+        }
+
+        let badTime: NSTimeInterval = -100
+        do {
+            _ = try generator.passwordAtTime(badTime)
+        } catch Generator.Error.InvalidTime {
+            // This is the expected type of error
+            return
+        } catch {
+            XCTFail("passwordAtTime(\(badTime)) threw an unexpected type of error: \(error))")
+            return
+        }
+        XCTFail("passwordAtTime(\(badTime)) should throw an error)")
+    }
+
     // The values in this test are found in Appendix D of the HOTP RFC
     // https://tools.ietf.org/html/rfc4226#appendix-D
     func testHOTPRFCValues() {


### PR DESCRIPTION
Add several tests which cover validation failures when generating a password and parsing failures when constructing a Token from a URL.

Also, fix a bug revealed by the tests, where parsing a URL with a non-integral counter parameter would return a token with an incorrect counter value.