### PR TITLE
Improve documentation comments

### DIFF
--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -41,10 +41,10 @@ public struct Generator: Equatable {
 
     /// Initializes a new password generator with the given parameters.
     ///
-    /// - parameter factor:    The moving factor
-    /// - parameter secret:    The shared secret
-    /// - parameter algorithm: The cryptographic hash function
-    /// - parameter digits:    The number of digits in the password
+    /// - parameter factor:    The moving factor.
+    /// - parameter secret:    The shared secret.
+    /// - parameter algorithm: The cryptographic hash function.
+    /// - parameter digits:    The number of digits in the password.
     ///
     /// - returns: A new password generator with the given parameters, or `nil` if the parameters
     ///            are invalid.
@@ -164,13 +164,13 @@ public struct Generator: Equatable {
     }
 
     /// A cryptographic hash function used to calculate the HMAC from which a password is derived.
-    /// The supported algorithms are SHA-1, SHA-256, and SHA-512
+    /// The supported algorithms are SHA-1, SHA-256, and SHA-512.
     public enum Algorithm: Equatable {
-        /// The SHA-1 hash function
+        /// The SHA-1 hash function.
         case SHA1
-        /// The SHA-256 hash function
+        /// The SHA-256 hash function.
         case SHA256
-        /// The SHA-512 hash function
+        /// The SHA-512 hash function.
         case SHA512
     }
 
@@ -179,7 +179,7 @@ public struct Generator: Equatable {
     public enum Error: ErrorType {
         /// The requested time is before the epoch date.
         case InvalidTime
-        /// The timer period is not a positive number of seconds
+        /// The timer period is not a positive number of seconds.
         case InvalidPeriod
         /// The number of digits is either too short to be secure, or too long to compute.
         case InvalidDigits

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -244,6 +244,11 @@ private extension Generator {
 
 private extension String {
     /// Prepends the given character to the beginning of `self` until it matches the given length.
+    ///
+    /// - parameter character: The padding character.
+    /// - parameter length:    The desired length of the padded string.
+    ///
+    /// - returns: A new string padded to the given length.
     func paddedWithCharacter(character: Character, toLength length: Int) -> String {
         let paddingCount = length - characters.count
         guard paddingCount > 0 else { return self }

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -35,7 +35,7 @@ public final class Keychain {
 
     /// Finds the persistent token with the given identifer, if one exists.
     ///
-    /// - parameter token: The persistent identifier for the desired token.
+    /// - parameter identifier: The persistent identifier for the desired token.
     ///
     /// - throws: A `Keychain.Error` if an error occurred.
     /// - returns: The persistent token, or `nil` if no token matched the given identifier.

--- a/Sources/Token.swift
+++ b/Sources/Token.swift
@@ -39,9 +39,9 @@ public struct Token: Equatable {
 
     /// Initializes a new token with the given parameters.
     ///
-    /// - parameter name:       The account name for the token (defaults to "")
-    /// - parameter issuer:     The entity which issued the token (defaults to "")
-    /// - parameter generator:  The password generator
+    /// - parameter name:       The account name for the token (defaults to "").
+    /// - parameter issuer:     The entity which issued the token (defaults to "").
+    /// - parameter generator:  The password generator.
     ///
     /// - returns: A new token with the given parameters.
     public init(name: String = defaultName, issuer: String = defaultIssuer, generator: Generator) {


### PR DESCRIPTION
 - Fix the parameter name in a `Keychain` doc comment
 - Expand the doc comment for the helper method `paddedWithCharacter(_:toLength:)`
 - Add a full stop at the end of each documentation comment