### PR TITLE
2.1 pre-release changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!--## [In development][master]-->
 
-## [2.1][]
+## [2.1][] (2016-11-16)
 #### Enhancements
 - Add watchOS support. ([#96](https://github.com/mattrubin/OneTimePassword/pull/96), [#98](https://github.com/mattrubin/OneTimePassword/pull/98), [#107](https://github.com/mattrubin/OneTimePassword/pull/107))
 - Inject Xcode path into the CommonCrypto modulemaps, to support non-standard Xcode locations. ([#92](https://github.com/mattrubin/OneTimePassword/pull/92), [#101](https://github.com/mattrubin/OneTimePassword/pull/101))

--- a/CommonCrypto/injectXcodePath.sh
+++ b/CommonCrypto/injectXcodePath.sh
@@ -47,14 +47,16 @@ absPath() {
 }
 
 scriptDir="`dirname $0`"
-scriptName="`basename $0`"
 absScriptDir="`cd $scriptDir; pwd`"
 
 main() {
+    echo "  ...in ${absScriptDir}..."
     for f in `find ${absScriptDir} -name module.modulemap`; do
+        echo "    ...updating file ${f}"
         cat ${f} | sed "s,${defaultXcodePath},${realXcodePath},g" > ${f}.new || fatal "Failed to update modulemap ${f}"
         mv ${f}.new ${f} || fatal "Failed to replace modulemap ${f}"
     done
+    echo "  ...with new path `xcode-select -p`"
 }
 
 main $*

--- a/Tests/KeychainTests.swift
+++ b/Tests/KeychainTests.swift
@@ -2,7 +2,7 @@
 //  KeychainTests.swift
 //  OneTimePassword
 //
-//  Copyright (c) 2013-2015 Matt Rubin and the OneTimePassword authors
+//  Copyright (c) 2013-2016 Matt Rubin and the OneTimePassword authors
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
 - Add the 2.1 release date to the changeling
 - Add debug logging to the Xcode path injection script (this was useful debugging an issue with `pod spec lint`)
 - Fix the copyright year in KeychainTests.swift