### PR TITLE
Update SwiftLint configuration

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,4 @@
 # Configuration for Hound (https://houndci.com)
 
 swift:
-  enabled: true
+  config_file: .swiftlint.yml

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,14 +20,12 @@ opt_in_rules:
   - switch_case_on_newline
   - vertical_whitespace
 disabled_rules:
-  - closure_parameter_position
   - colon
   - comma
   - cyclomatic_complexity
   - function_body_length
   - line_length
   - syntactic_sugar
-  - unused_closure_parameter
   - valid_docs
 
 trailing_comma:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,9 +24,11 @@ disabled_rules:
   - comma
   - cyclomatic_complexity
   - function_body_length
-  - line_length
   - syntactic_sugar
   - valid_docs
 
 trailing_comma:
   mandatory_comma: true
+
+line_length:
+  warning: 120

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,7 @@ opt_in_rules:
   - conditional_returns_on_newline
   - empty_count
   - explicit_init
+  - file_header
   - first_where
 #  - missing_docs
   - nimble_operator
@@ -32,3 +33,30 @@ trailing_comma:
 
 line_length:
   warning: 120
+
+file_header:
+  required_pattern: |
+    \/\/
+    \/\/  (.+).swift
+    \/\/  OneTimePassword
+    \/\/
+    \/\/  Copyright \(c\) (\d{4}|\d{4}-\d{4}) Matt Rubin and the OneTimePassword authors
+    \/\/
+    \/\/  Permission is hereby granted, free of charge, to any person obtaining a copy
+    \/\/  of this software and associated documentation files \(the "Software"\), to deal
+    \/\/  in the Software without restriction, including without limitation the rights
+    \/\/  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    \/\/  copies of the Software, and to permit persons to whom the Software is
+    \/\/  furnished to do so, subject to the following conditions:
+    \/\/
+    \/\/  The above copyright notice and this permission notice shall be included in all
+    \/\/  copies or substantial portions of the Software.
+    \/\/
+    \/\/  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    \/\/  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    \/\/  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    \/\/  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    \/\/  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    \/\/  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    \/\/  SOFTWARE.
+    \/\/

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -98,7 +98,8 @@ private func algorithmFromString(_ string: String) -> Generator.Algorithm? {
     }
 }
 
-private func urlForToken(name: String, issuer: String, factor: Generator.Factor, algorithm: Generator.Algorithm, digits: Int) throws -> URL {
+private func urlForToken(name: String, issuer: String, factor: Generator.Factor, algorithm: Generator.Algorithm,
+                         digits: Int) throws -> URL {
     var urlComponents = URLComponents()
     urlComponents.scheme = kOTPAuthScheme
     urlComponents.path = "/" + name
@@ -164,8 +165,10 @@ private func token(from url: URL, secret externalSecret: Data? = nil) -> Token? 
     }
 
     guard let factor = parse(url.host, with: factorParser, defaultTo: nil),
-        let secret = parse(queryDictionary[kQuerySecretKey], with: { MF_Base32Codec.data(fromBase32String: $0) }, overrideWith: externalSecret),
-        let algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString, defaultTo: defaultAlgorithm),
+        let secret = parse(queryDictionary[kQuerySecretKey], with: { MF_Base32Codec.data(fromBase32String: $0) },
+                           overrideWith: externalSecret),
+        let algorithm = parse(queryDictionary[kQueryAlgorithmKey], with: algorithmFromString,
+                              defaultTo: defaultAlgorithm),
         let digits = parse(queryDictionary[kQueryDigitsKey], with: { Int($0) }, defaultTo: defaultDigits),
         let generator = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits) else {
             return nil
@@ -200,7 +203,8 @@ private func token(from url: URL, secret externalSecret: Data? = nil) -> Token? 
     return Token(name: name, issuer: issuer, generator: generator)
 }
 
-private func parse<P, T>(_ item: P?, with parser: ((P) -> T?), defaultTo defaultValue: T? = nil, overrideWith overrideValue: T? = nil) -> T? {
+private func parse<P, T>(_ item: P?, with parser: ((P) -> T?), defaultTo defaultValue: T? = nil,
+                         overrideWith overrideValue: T? = nil) -> T? {
     if let value = overrideValue {
         return value
     }

--- a/Tests/EquatableTests.swift
+++ b/Tests/EquatableTests.swift
@@ -56,10 +56,11 @@ class EquatableTests: XCTestCase {
 
     func testGeneratorEquality() {
         let g = Generator(factor: .counter(0), secret: Data(), algorithm: .SHA1, digits: 6)
+        let badData = "0".data(using: String.Encoding.utf8)!
 
         XCTAssert(g == Generator(factor: .counter(0), secret: Data(), algorithm: .SHA1, digits: 6))
         XCTAssert(g != Generator(factor: .counter(1), secret: Data(), algorithm: .SHA1, digits: 6))
-        XCTAssert(g != Generator(factor: .counter(0), secret: "0".data(using: String.Encoding.utf8)!, algorithm: .SHA1, digits: 6))
+        XCTAssert(g != Generator(factor: .counter(0), secret: badData, algorithm: .SHA1, digits: 6))
         XCTAssert(g != Generator(factor: .counter(0), secret: Data(), algorithm: .SHA256, digits: 6))
         XCTAssert(g != Generator(factor: .counter(0), secret: Data(), algorithm: .SHA1, digits: 8))
     }

--- a/Tests/TokenSerializationTests.swift
+++ b/Tests/TokenSerializationTests.swift
@@ -93,18 +93,21 @@ class TokenSerializationTests: XCTestCase {
                                 XCTAssertEqual(url.host!, expectedHost, "The url host should be \"\(expectedHost)\"")
                                 // Test name
                                 let path = url.path
-                                XCTAssertEqual(path.substring(from: path.index(after: path.startIndex)), name, "The url path should be \"\(name)\"")
+                                XCTAssertEqual(path.substring(from: path.index(after: path.startIndex)), name,
+                                               "The url path should be \"\(name)\"")
 
                                 let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
                                 let items = urlComponents?.queryItems
                                 let expectedItemCount = 4
-                                XCTAssertEqual(items?.count, expectedItemCount, "There shouldn't be any unexpected query arguments: \(url)")
+                                XCTAssertEqual(items?.count, expectedItemCount,
+                                               "There shouldn't be any unexpected query arguments: \(url)")
 
                                 var queryArguments = Dictionary<String, String>()
                                 for item in items ?? [] {
                                     queryArguments[item.name] = item.value
                                 }
-                                XCTAssertEqual(queryArguments.count, expectedItemCount, "There shouldn't be any unexpected query arguments: \(url)")
+                                XCTAssertEqual(queryArguments.count, expectedItemCount,
+                                               "There shouldn't be any unexpected query arguments: \(url)")
 
                                 // Test algorithm
                                 let algorithmString: String = {
@@ -116,29 +119,37 @@ class TokenSerializationTests: XCTestCase {
                                     case .SHA512:
                                         return "SHA512"
                                     }}(algorithm)
-                                XCTAssertEqual(queryArguments["algorithm"]!, algorithmString, "The algorithm value should be \"\(algorithmString)\"")
+                                XCTAssertEqual(queryArguments["algorithm"]!, algorithmString,
+                                               "The algorithm value should be \"\(algorithmString)\"")
                                 // Test digits
-                                XCTAssertEqual(queryArguments["digits"]!, String(digitNumber), "The digits value should be \"\(digitNumber)\"")
+                                XCTAssertEqual(queryArguments["digits"]!, String(digitNumber),
+                                               "The digits value should be \"\(digitNumber)\"")
                                 // Test secret
-                                XCTAssertNil(queryArguments["secret"], "The url query string should not contain the secret")
+                                XCTAssertNil(queryArguments["secret"],
+                                             "The url query string should not contain the secret")
 
                                 // Test period
                                 switch factor {
                                 case .timer(let period):
-                                    XCTAssertEqual(queryArguments["period"]!, String(Int(period)), "The period value should be \"\(period)\"")
+                                    XCTAssertEqual(queryArguments["period"]!, String(Int(period)),
+                                                   "The period value should be \"\(period)\"")
                                 default:
-                                    XCTAssertNil(queryArguments["period"], "The url query string should not contain the period")
+                                    XCTAssertNil(queryArguments["period"],
+                                                 "The url query string should not contain the period")
                                 }
                                 // Test counter
                                 switch factor {
                                 case .counter(let counter):
-                                    XCTAssertEqual(queryArguments["counter"]!, String(counter), "The counter value should be \"\(counter)\"")
+                                    XCTAssertEqual(queryArguments["counter"]!, String(counter),
+                                                   "The counter value should be \"\(counter)\"")
                                 default:
-                                    XCTAssertNil(queryArguments["counter"], "The url query string should not contain the counter")
+                                    XCTAssertNil(queryArguments["counter"],
+                                                 "The url query string should not contain the counter")
                                 }
 
                                 // Test issuer
-                                XCTAssertEqual(queryArguments["issuer"]!, issuer, "The issuer value should be \"\(issuer)\"")
+                                XCTAssertEqual(queryArguments["issuer"]!, issuer,
+                                               "The issuer value should be \"\(issuer)\"")
 
                                 // Check url again
                                 guard let checkURL = try? token.toURL() else {


### PR DESCRIPTION
- Limit line length to 120 characters
- Enforce consistent file header comments
- Re-enable closure parameter lint rules
