### PR TITLE
Swift 3 code review

### DIFF
--- a/OneTimePasswordLegacyTests/OTPToken.swift
+++ b/OneTimePasswordLegacyTests/OTPToken.swift
@@ -26,8 +26,6 @@
 import Foundation
 import OneTimePassword
 
-// swiftlint:disable missing_docs
-
 /// `OTPToken` is a mutable, Objective-C-compatible wrapper around `OneTimePassword.Token`. For more
 /// information about its properties and methods, consult the underlying `OneTimePassword`
 /// documentation.
@@ -50,7 +48,7 @@ public final class OTPToken: NSObject {
     private static var defaultInitialCounter: UInt64 = 0
     private static var defaultPeriod: TimeInterval = 30
 
-    private func updateWithToken(_ token: Token) {
+    private func update(with token: Token) {
         self.name = token.name
         self.issuer = token.issuer
 
@@ -70,7 +68,7 @@ public final class OTPToken: NSObject {
 
     fileprivate convenience init(token: Token) {
         self.init()
-        updateWithToken(token)
+        update(with: token)
     }
 
     public func validate() -> Bool {
@@ -79,11 +77,13 @@ public final class OTPToken: NSObject {
 }
 
 public extension OTPToken {
-    static func tokenWithURL(_ url: URL) -> Self? {
-        return tokenWithURL(url, secret: nil)
+    @objc(tokenWithURL:)
+    static func token(from url: URL) -> Self? {
+        return token(from: url, secret: nil)
     }
 
-    static func tokenWithURL(_ url: URL, secret: Data?) -> Self? {
+    @objc(tokenWithURL:secret:)
+    static func token(from url: URL, secret: Data?) -> Self? {
         guard let token = Token(url: url, secret: secret) else {
             return nil
         }

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -32,7 +32,11 @@ func HMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
     let macOut = UnsafeMutablePointer<UInt8>.allocate(capacity: hashLength)
     defer { macOut.deallocate(capacity: hashLength) }
 
-    CCHmac(hashFunction, (key as NSData).bytes, key.count, (data as NSData).bytes, data.count, macOut)
+    key.withUnsafeBytes { keyBytes in
+        data.withUnsafeBytes { dataBytes in
+            CCHmac(hashFunction, keyBytes, key.count, dataBytes, data.count, macOut)
+        }
+    }
 
     return Data(bytes: macOut, count: hashLength)
 }

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -106,13 +106,14 @@ public final class Keychain {
 // MARK: - Private
 
 private let kOTPService = "me.mattrubin.onetimepassword.token"
+private let urlStringEncoding = String.Encoding.utf8
 
 private extension Token {
     func keychainAttributes() throws -> [String: AnyObject] {
         let url = try self.toURL()
         // This line supports the different optionality of `absoluteString` between Xcode 7 and 8
         let urlString: String? = url.absoluteString
-        guard let data = urlString?.data(using: String.Encoding.utf8) else {
+        guard let data = urlString?.data(using: urlStringEncoding) else {
             throw Keychain.Error.tokenSerializationFailure
         }
         return [
@@ -126,10 +127,10 @@ private extension Token {
 private extension PersistentToken {
     init?(keychainDictionary: NSDictionary) {
         guard let urlData = keychainDictionary[kSecAttrGeneric as String] as? Data,
-            let string = NSString(data: urlData, encoding: String.Encoding.utf8.rawValue),
+            let urlString = String(data: urlData, encoding: urlStringEncoding),
             let secret = keychainDictionary[kSecValueData as String] as? Data,
             let keychainItemRef = keychainDictionary[kSecValuePersistentRef as String] as? Data,
-            let url = URL(string: string as String),
+            let url = URL(string: urlString as String),
             let token = Token(url: url, secret: secret) else {
                 return nil
         }

--- a/Tests/KeychainTests.swift
+++ b/Tests/KeychainTests.swift
@@ -25,13 +25,14 @@
 
 import XCTest
 import OneTimePassword
+import Base32
 
 let testToken = Token(
     name: "Name",
     issuer: "Issuer",
     generator: Generator(
         factor: .timer(period: 45),
-        secret: NSData(base32String: "AAAQEAYEAUDAOCAJBIFQYDIOB4") as Data,
+        secret: MF_Base32Codec.data(fromBase32String: "AAAQEAYEAUDAOCAJBIFQYDIOB4"),
         algorithm: .SHA256,
         digits: 8
     )!


### PR DESCRIPTION
Assorted changes from a review of the Swift 3 update:
  - Use a constant `String.Encoding` for keychain conversion of token URLs
  - Use Data's `withUnsafeBytes` instead of casting to `NSData`
  - Use the Base32 API directly to avoid creating and then bridging `NSData`
  - Update the `OTPToken` shim with Swift 3 API conventions