### PR TITLE
Convert Algorithm case names to lowercase, following Swift 3 conventions

### DIFF
--- a/OneTimePasswordLegacyTests/OTPToken.swift
+++ b/OneTimePasswordLegacyTests/OTPToken.swift
@@ -43,7 +43,7 @@ public final class OTPToken: NSObject {
 
     private static let defaultName: String = ""
     private static let defaultIssuer: String = ""
-    private static let defaultAlgorithm: OTPAlgorithm = .SHA1
+    private static let defaultAlgorithm: OTPAlgorithm = .sha1
     private static var defaultDigits: UInt = 6
     private static var defaultInitialCounter: UInt64 = 0
     private static var defaultPeriod: TimeInterval = 30
@@ -108,9 +108,9 @@ public enum OTPTokenType: UInt8 {
 
 @objc
 public enum OTPAlgorithm: UInt32 {
-    case SHA1
-    case SHA256
-    case SHA512
+    @objc(OTPAlgorithmSHA1)   case sha1
+    @objc(OTPAlgorithmSHA256) case sha256
+    @objc(OTPAlgorithmSHA512) case sha512
 }
 
 // MARK: Conversion
@@ -118,12 +118,12 @@ public enum OTPAlgorithm: UInt32 {
 private extension OTPAlgorithm {
     init(_ generatorAlgorithm: Generator.Algorithm) {
         switch generatorAlgorithm {
-        case .SHA1:
-            self = .SHA1
-        case .SHA256:
-            self = .SHA256
-        case .SHA512:
-            self = .SHA512
+        case .sha1:
+            self = .sha1
+        case .sha256:
+            self = .sha256
+        case .sha512:
+            self = .sha512
         }
     }
 }
@@ -151,11 +151,11 @@ private func factorForOTPToken(_ otpToken: OTPToken) -> Generator.Factor {
 
 private func algorithmForOTPAlgorithm(_ algorithm: OTPAlgorithm) -> Generator.Algorithm {
     switch algorithm {
-    case .SHA1:
-        return .SHA1
-    case .SHA256:
-        return .SHA256
-    case .SHA512:
-        return .SHA512
+    case .sha1:
+        return .sha1
+    case .sha256:
+        return .sha256
+    case .sha512:
+        return .sha512
     }
 }

--- a/OneTimePasswordLegacyTests/OTPTokenTests.swift
+++ b/OneTimePasswordLegacyTests/OTPTokenTests.swift
@@ -33,7 +33,7 @@ class OTPTokenTests: XCTestCase {
         XCTAssertEqual(token.issuer, "")
         XCTAssertEqual(token.type, OTPTokenType.timer)
         XCTAssertEqual(token.secret, Data())
-        XCTAssertEqual(token.algorithm, OTPAlgorithm.SHA1)
+        XCTAssertEqual(token.algorithm, OTPAlgorithm.sha1)
         XCTAssertEqual(token.digits, 6)
         XCTAssertEqual(token.period, 30)
         XCTAssertEqual(token.counter, 0)

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -45,11 +45,11 @@ private extension Generator.Algorithm {
     /// The corresponding CommonCrypto hash function and hash length.
     var hashInfo: (hashFunction: CCHmacAlgorithm, hashLength: Int) {
         switch self {
-        case .SHA1:
+        case .sha1:
             return (CCHmacAlgorithm(kCCHmacAlgSHA1), Int(CC_SHA1_DIGEST_LENGTH))
-        case .SHA256:
+        case .sha256:
             return (CCHmacAlgorithm(kCCHmacAlgSHA256), Int(CC_SHA256_DIGEST_LENGTH))
-        case .SHA512:
+        case .sha512:
             return (CCHmacAlgorithm(kCCHmacAlgSHA512), Int(CC_SHA512_DIGEST_LENGTH))
         }
     }

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -169,11 +169,11 @@ public struct Generator: Equatable {
     /// The supported algorithms are SHA-1, SHA-256, and SHA-512.
     public enum Algorithm: Equatable {
         /// The SHA-1 hash function.
-        case SHA1
+        case sha1
         /// The SHA-256 hash function.
-        case SHA256
+        case sha256
         /// The SHA-512 hash function.
-        case SHA512
+        case sha512
     }
 
     /// An error type enum representing the various errors a `Generator` can throw when computing a

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -54,7 +54,7 @@ internal enum SerializationError: Swift.Error {
     case urlGenerationFailure
 }
 
-private let defaultAlgorithm: Generator.Algorithm = .SHA1
+private let defaultAlgorithm: Generator.Algorithm = .sha1
 private let defaultDigits: Int = 6
 private let defaultCounter: UInt64 = 0
 private let defaultPeriod: TimeInterval = 30
@@ -76,11 +76,11 @@ private let kAlgorithmSHA512 = "SHA512"
 
 private func stringForAlgorithm(_ algorithm: Generator.Algorithm) -> String {
     switch algorithm {
-    case .SHA1:
+    case .sha1:
         return kAlgorithmSHA1
-    case .SHA256:
+    case .sha256:
         return kAlgorithmSHA256
-    case .SHA512:
+    case .sha512:
         return kAlgorithmSHA512
     }
 }
@@ -88,11 +88,11 @@ private func stringForAlgorithm(_ algorithm: Generator.Algorithm) -> String {
 private func algorithmFromString(_ string: String) -> Generator.Algorithm? {
     switch string {
     case kAlgorithmSHA1:
-        return .SHA1
+        return .sha1
     case kAlgorithmSHA256:
-        return .SHA256
+        return .sha256
     case kAlgorithmSHA512:
-        return .SHA512
+        return .sha512
     default:
         return nil
     }

--- a/Tests/EquatableTests.swift
+++ b/Tests/EquatableTests.swift
@@ -55,19 +55,19 @@ class EquatableTests: XCTestCase {
     }
 
     func testGeneratorEquality() {
-        let g = Generator(factor: .counter(0), secret: Data(), algorithm: .SHA1, digits: 6)
+        let g = Generator(factor: .counter(0), secret: Data(), algorithm: .sha1, digits: 6)
         let badData = "0".data(using: String.Encoding.utf8)!
 
-        XCTAssert(g == Generator(factor: .counter(0), secret: Data(), algorithm: .SHA1, digits: 6))
-        XCTAssert(g != Generator(factor: .counter(1), secret: Data(), algorithm: .SHA1, digits: 6))
-        XCTAssert(g != Generator(factor: .counter(0), secret: badData, algorithm: .SHA1, digits: 6))
-        XCTAssert(g != Generator(factor: .counter(0), secret: Data(), algorithm: .SHA256, digits: 6))
-        XCTAssert(g != Generator(factor: .counter(0), secret: Data(), algorithm: .SHA1, digits: 8))
+        XCTAssert(g == Generator(factor: .counter(0), secret: Data(), algorithm: .sha1, digits: 6))
+        XCTAssert(g != Generator(factor: .counter(1), secret: Data(), algorithm: .sha1, digits: 6))
+        XCTAssert(g != Generator(factor: .counter(0), secret: badData, algorithm: .sha1, digits: 6))
+        XCTAssert(g != Generator(factor: .counter(0), secret: Data(), algorithm: .sha256, digits: 6))
+        XCTAssert(g != Generator(factor: .counter(0), secret: Data(), algorithm: .sha1, digits: 8))
     }
 
     func testTokenEquality() {
-        guard let generator = Generator(factor: .counter(0), secret: Data(), algorithm: .SHA1, digits: 6),
-            let other_generator = Generator(factor: .counter(1), secret: Data(), algorithm: .SHA512, digits: 8) else {
+        guard let generator = Generator(factor: .counter(0), secret: Data(), algorithm: .sha1, digits: 6),
+            let other_generator = Generator(factor: .counter(1), secret: Data(), algorithm: .sha512, digits: 8) else {
                 XCTFail()
                 return
         }

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -31,7 +31,7 @@ class GeneratorTests: XCTestCase {
         // Create a generator
         let factor = OneTimePassword.Generator.Factor.counter(111)
         let secret = "12345678901234567890".data(using: String.Encoding.ascii)!
-        let algorithm = Generator.Algorithm.SHA256
+        let algorithm = Generator.Algorithm.sha256
         let digits = 8
 
         let generator = Generator(
@@ -49,7 +49,7 @@ class GeneratorTests: XCTestCase {
         // Create another generator
         let other_factor = OneTimePassword.Generator.Factor.timer(period: 123)
         let other_secret = "09876543210987654321".data(using: String.Encoding.ascii)!
-        let other_algorithm = Generator.Algorithm.SHA512
+        let other_algorithm = Generator.Algorithm.sha512
         let other_digits = 7
 
         let other_generator = Generator(
@@ -84,9 +84,9 @@ class GeneratorTests: XCTestCase {
             let timer = Generator.Factor.timer(period: period)
             let counter = Generator.Factor.counter(count)
             let secret = "12345678901234567890".data(using: String.Encoding.ascii)!
-            let hotp = Generator(factor: counter, secret: secret, algorithm: .SHA1, digits: 6)
+            let hotp = Generator(factor: counter, secret: secret, algorithm: .sha1, digits: 6)
                 .flatMap { try? $0.password(at: time) }
-            let totp = Generator(factor: timer, secret: secret, algorithm: .SHA1, digits: 6)
+            let totp = Generator(factor: timer, secret: secret, algorithm: .sha1, digits: 6)
                 .flatMap { try? $0.password(at: time) }
             XCTAssertEqual(hotp, totp,
                 "TOTP with \(timer) should match HOTP with counter \(counter) at time \(time).")
@@ -119,7 +119,7 @@ class GeneratorTests: XCTestCase {
             let generator = Generator(
                 factor: .counter(0),
                 secret: Data(),
-                algorithm: .SHA1,
+                algorithm: .sha1,
                 digits: digits
             )
             // If the digits are invalid, password generation should throw an error
@@ -134,7 +134,7 @@ class GeneratorTests: XCTestCase {
                 let generator = Generator(
                     factor: .timer(period: period),
                     secret: Data(),
-                    algorithm: .SHA1,
+                    algorithm: .sha1,
                     digits: digits
                 )
                 // If the digits or period are invalid, password generation should throw an error
@@ -152,7 +152,7 @@ class GeneratorTests: XCTestCase {
         guard let generator = Generator(
             factor: .timer(period: 30),
             secret: Data(),
-            algorithm: .SHA1,
+            algorithm: .sha1,
             digits: 6
             ) else {
                 XCTFail("Failed to initialize a Generator.")
@@ -221,7 +221,7 @@ class GeneratorTests: XCTestCase {
             9: "520489",
         ]
         for (counter, expectedPassword) in expectedValues {
-            let generator = Generator(factor: .counter(counter), secret: secret, algorithm: .SHA1, digits: 6)
+            let generator = Generator(factor: .counter(counter), secret: secret, algorithm: .sha1, digits: 6)
             let password = generator.flatMap { try? $0.password(at: 0) }
             XCTAssertEqual(password, expectedPassword,
                 "The generator did not produce the expected OTP.")
@@ -232,17 +232,17 @@ class GeneratorTests: XCTestCase {
     // https://tools.ietf.org/html/rfc6238#appendix-B
     func testTOTPRFCValues() {
         let secretKeys: [Generator.Algorithm: String] = [
-            .SHA1:   "12345678901234567890",
-            .SHA256: "12345678901234567890123456789012",
-            .SHA512: "1234567890123456789012345678901234567890123456789012345678901234",
+            .sha1:   "12345678901234567890",
+            .sha256: "12345678901234567890123456789012",
+            .sha512: "1234567890123456789012345678901234567890123456789012345678901234",
         ]
 
         let times: [TimeInterval] = [59, 1111111109, 1111111111, 1234567890, 2000000000, 20000000000]
 
         let expectedValues: [Generator.Algorithm: [String]] = [
-            .SHA1:   ["94287082", "07081804", "14050471", "89005924", "69279037", "65353130"],
-            .SHA256: ["46119246", "68084774", "67062674", "91819424", "90698825", "77737706"],
-            .SHA512: ["90693936", "25091201", "99943326", "93441116", "38618901", "47863826"],
+            .sha1:   ["94287082", "07081804", "14050471", "89005924", "69279037", "65353130"],
+            .sha256: ["46119246", "68084774", "67062674", "91819424", "90698825", "77737706"],
+            .sha512: ["90693936", "25091201", "99943326", "93441116", "38618901", "47863826"],
         ]
 
         for (algorithm, secretKey) in secretKeys {
@@ -265,9 +265,9 @@ class GeneratorTests: XCTestCase {
         let times: [TimeInterval] = [1111111111, 1234567890, 2000000000]
 
         let expectedValues: [Generator.Algorithm: [String]] = [
-            .SHA1:   ["050471", "005924", "279037"],
-            .SHA256: ["584430", "829826", "428693"],
-            .SHA512: ["380122", "671578", "464532"],
+            .sha1:   ["050471", "005924", "279037"],
+            .sha256: ["584430", "829826", "428693"],
+            .sha512: ["380122", "671578", "464532"],
         ]
 
         for (algorithm, expectedPasswords) in expectedValues {
@@ -285,7 +285,7 @@ class GeneratorTests: XCTestCase {
 private extension Generator {
     init(unvalidatedFactor factor: Factor = .timer(period: 30),
          unvalidatedSecret secret: Data = Data(),
-         unvalidatedAlgorithm algorithm: Algorithm = .SHA1,
+         unvalidatedAlgorithm algorithm: Algorithm = .sha1,
          unvalidatedDigits digits: Int = 8) {
         self.factor = factor
         self.secret = secret

--- a/Tests/KeychainTests.swift
+++ b/Tests/KeychainTests.swift
@@ -33,7 +33,7 @@ let testToken = Token(
     generator: Generator(
         factor: .timer(period: 45),
         secret: MF_Base32Codec.data(fromBase32String: "AAAQEAYEAUDAOCAJBIFQYDIOB4"),
-        algorithm: .SHA256,
+        algorithm: .sha256,
         digits: 8
     )!
 )

--- a/Tests/TokenSerializationTests.swift
+++ b/Tests/TokenSerializationTests.swift
@@ -47,7 +47,7 @@ class TokenSerializationTests: XCTestCase {
         "1234567890123456789012345678901234567890123456789012345678901234",
         "",
     ]
-    let algorithms: [OneTimePassword.Generator.Algorithm] = [.SHA1, .SHA256, .SHA512]
+    let algorithms: [OneTimePassword.Generator.Algorithm] = [.sha1, .sha256, .sha512]
     let digits = [6, 7, 8]
 
     func testSerialization() {
@@ -112,11 +112,11 @@ class TokenSerializationTests: XCTestCase {
                                 // Test algorithm
                                 let algorithmString: String = {
                                     switch $0 {
-                                    case .SHA1:
+                                    case .sha1:
                                         return "SHA1"
-                                    case .SHA256:
+                                    case .sha256:
                                         return "SHA256"
-                                    case .SHA512:
+                                    case .sha512:
                                         return "SHA512"
                                     }}(algorithm)
                                 XCTAssertEqual(queryArguments["algorithm"]!, algorithmString,

--- a/Tests/TokenTests.swift
+++ b/Tests/TokenTests.swift
@@ -37,7 +37,7 @@ class TokenTests: XCTestCase {
         guard let generator = Generator(
             factor: .counter(111),
             secret: secretData,
-            algorithm: .SHA1,
+            algorithm: .sha1,
             digits: 6
         ) else {
             XCTFail()
@@ -60,7 +60,7 @@ class TokenTests: XCTestCase {
         guard let other_generator = Generator(
             factor: .timer(period: 123),
             secret: otherSecretData,
-            algorithm: .SHA512,
+            algorithm: .sha512,
             digits: 8
         ) else {
             XCTFail()
@@ -87,7 +87,7 @@ class TokenTests: XCTestCase {
         guard let generator = Generator(
             factor: .counter(0),
             secret: Data(),
-            algorithm: .SHA1,
+            algorithm: .sha1,
             digits: 6
         ) else {
             XCTFail()
@@ -113,7 +113,7 @@ class TokenTests: XCTestCase {
         guard let timerGenerator = Generator(
             factor: .timer(period: 30),
             secret: secretData,
-            algorithm: .SHA1,
+            algorithm: .sha1,
             digits: 6
         ) else {
             XCTFail()
@@ -135,7 +135,7 @@ class TokenTests: XCTestCase {
         guard let counterGenerator = Generator(
             factor: .counter(12345),
             secret: otherSecretData,
-            algorithm: .SHA1,
+            algorithm: .sha1,
             digits: 6
         ) else {
             XCTFail()
@@ -159,7 +159,7 @@ class TokenTests: XCTestCase {
         guard let timerGenerator = Generator(
             factor: .timer(period: 30),
             secret: secretData,
-            algorithm: .SHA1,
+            algorithm: .sha1,
             digits: 6
         ) else {
             XCTFail()
@@ -174,7 +174,7 @@ class TokenTests: XCTestCase {
         guard let counterGenerator = Generator(
             factor: .counter(count),
             secret: otherSecretData,
-            algorithm: .SHA1,
+            algorithm: .sha1,
             digits: 6
         ) else {
             XCTFail()


### PR DESCRIPTION
While not made explicitly clear in the API design guidelines, in the Foundation Swift 3 API even names with are acronyms are lower-camel-case.

https://swift.org/documentation/api-design-guidelines/#follow-case-conventions
