### PR TITLE
Convert password(at:) to take a Date instead of a TimeInterval

### DIFF
--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -62,12 +62,12 @@ public struct Generator: Equatable {
 
     /// Generates the password for the given point in time.
     ///
-    /// - parameter time: The target time, as seconds since the Unix epoch.
-    ///                   The time value must be positive.
+    /// - parameter time: The target time, represented as a `Date`.
+    ///                   The time must not be before the Unix epoch.
     ///
     /// - throws: A `Generator.Error` if a valid password cannot be generated for the given time.
     /// - returns: The generated password, or throws an error if a password could not be generated.
-    public func password(at time: TimeInterval) throws -> String {
+    public func password(at time: Date) throws -> String {
         guard Generator.validateDigits(digits) else {
             throw Error.invalidDigits
         }
@@ -145,22 +145,24 @@ public struct Generator: Equatable {
         /// it will be the number of time steps since the Unix epoch, based on the associated
         /// period value.
         ///
-        /// - parameter time: The target time, as seconds since the Unix epoch.
+        /// - parameter time: The target time, represented as a `Date`.
+        ///                   The time must not be before the Unix epoch.
         ///
         /// - throws: A `Generator.Error` if a valid counter cannot be calculated.
         /// - returns: The counter value needed to generate the password for the target time.
-        fileprivate func counterValue(at time: TimeInterval) throws -> UInt64 {
+        fileprivate func counterValue(at time: Date) throws -> UInt64 {
             switch self {
             case .counter(let counter):
                 return counter
             case .timer(let period):
-                guard Generator.validateTime(time) else {
+                let timeSinceEpoch = time.timeIntervalSince1970
+                guard Generator.validateTime(timeSinceEpoch) else {
                     throw Error.invalidTime
                 }
                 guard Generator.validatePeriod(period) else {
                     throw Error.invalidPeriod
                 }
-                return UInt64(time / period)
+                return UInt64(timeSinceEpoch / period)
             }
         }
     }
@@ -234,9 +236,9 @@ private extension Generator {
         return (period > 0)
     }
 
-    static func validateTime(_ time: TimeInterval) -> Bool {
+    static func validateTime(_ timeSinceEpoch: TimeInterval) -> Bool {
         // The time must be positive to produce a valid counter value.
-        return (time >= 0)
+        return (timeSinceEpoch >= 0)
     }
 }
 

--- a/Sources/Token.swift
+++ b/Sources/Token.swift
@@ -66,7 +66,7 @@ public struct Token: Equatable {
     ///
     /// - returns: The current password, or `nil` if a password could not be generated.
     public var currentPassword: String? {
-        let currentTime = Date().timeIntervalSince1970
+        let currentTime = Date()
         return try? generator.password(at: currentTime)
     }
 

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -80,7 +80,8 @@ class GeneratorTests: XCTestCase {
             (10000000000, 90, 111111111),
         ]
 
-        for (time, period, count) in factors {
+        for (timeSinceEpoch, period, count) in factors {
+            let time = Date(timeIntervalSince1970: timeSinceEpoch)
             let timer = Generator.Factor.timer(period: period)
             let counter = Generator.Factor.counter(count)
             let secret = "12345678901234567890".data(using: String.Encoding.ascii)!
@@ -159,7 +160,7 @@ class GeneratorTests: XCTestCase {
                 return
         }
 
-        let badTime: TimeInterval = -100
+        let badTime = Date(timeIntervalSince1970: -100)
         do {
             _ = try generator.password(at: badTime)
         } catch Generator.Error.invalidTime {
@@ -174,7 +175,7 @@ class GeneratorTests: XCTestCase {
 
     func testPasswordWithInvalidPeriod() {
         let generator = Generator(unvalidatedFactor: .timer(period: 0))
-        let time: TimeInterval = 100
+        let time = Date(timeIntervalSince1970: 100)
 
         do {
             _ = try generator.password(at: time)
@@ -190,7 +191,7 @@ class GeneratorTests: XCTestCase {
 
     func testPasswordWithInvalidDigits() {
         let generator = Generator(unvalidatedDigits: 3)
-        let time: TimeInterval = 100
+        let time = Date(timeIntervalSince1970: 100)
 
         do {
             _ = try generator.password(at: time)
@@ -222,7 +223,8 @@ class GeneratorTests: XCTestCase {
         ]
         for (counter, expectedPassword) in expectedValues {
             let generator = Generator(factor: .counter(counter), secret: secret, algorithm: .sha1, digits: 6)
-            let password = generator.flatMap { try? $0.password(at: 0) }
+            let time = Date(timeIntervalSince1970: 0)
+            let password = generator.flatMap { try? $0.password(at: time) }
             XCTAssertEqual(password, expectedPassword,
                 "The generator did not produce the expected OTP.")
         }
@@ -251,7 +253,8 @@ class GeneratorTests: XCTestCase {
 
             for i in 0..<times.count {
                 let expectedPassword = expectedValues[algorithm]?[i]
-                let password = generator.flatMap { try? $0.password(at: times[i]) }
+                let time = Date(timeIntervalSince1970: times[i])
+                let password = generator.flatMap { try? $0.password(at: time) }
                 XCTAssertEqual(password, expectedPassword,
                     "Incorrect result for \(algorithm) at \(times[i])")
             }
@@ -274,7 +277,8 @@ class GeneratorTests: XCTestCase {
             let generator = Generator(factor: .timer(period: 30), secret: secret, algorithm: algorithm, digits: 6)
             for i in 0..<times.count {
                 let expectedPassword = expectedPasswords[i]
-                let password = generator.flatMap { try? $0.password(at: times[i]) }
+                let time = Date(timeIntervalSince1970: times[i])
+                let password = generator.flatMap { try? $0.password(at: time) }
                 XCTAssertEqual(password, expectedPassword,
                     "Incorrect result for \(algorithm) at \(times[i])")
             }

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -239,7 +239,7 @@ class GeneratorTests: XCTestCase {
             .sha512: "1234567890123456789012345678901234567890123456789012345678901234",
         ]
 
-        let times: [TimeInterval] = [59, 1111111109, 1111111111, 1234567890, 2000000000, 20000000000]
+        let timesSinceEpoch: [TimeInterval] = [59, 1111111109, 1111111111, 1234567890, 2000000000, 20000000000]
 
         let expectedValues: [Generator.Algorithm: [String]] = [
             .sha1:   ["94287082", "07081804", "14050471", "89005924", "69279037", "65353130"],
@@ -251,12 +251,11 @@ class GeneratorTests: XCTestCase {
             let secret = secretKey.data(using: String.Encoding.ascii)!
             let generator = Generator(factor: .timer(period: 30), secret: secret, algorithm: algorithm, digits: 8)
 
-            for i in 0..<times.count {
-                let expectedPassword = expectedValues[algorithm]?[i]
-                let time = Date(timeIntervalSince1970: times[i])
+            for (timeSinceEpoch, expectedPassword) in zip(timesSinceEpoch, expectedValues[algorithm]!) {
+                let time = Date(timeIntervalSince1970: timeSinceEpoch)
                 let password = generator.flatMap { try? $0.password(at: time) }
                 XCTAssertEqual(password, expectedPassword,
-                    "Incorrect result for \(algorithm) at \(times[i])")
+                    "Incorrect result for \(algorithm) at \(timeSinceEpoch)")
             }
         }
     }
@@ -265,7 +264,7 @@ class GeneratorTests: XCTestCase {
     // https://code.google.com/p/google-authenticator/source/browse/mobile/ios/Classes/TOTPGeneratorTest.m
     func testTOTPGoogleValues() {
         let secret = "12345678901234567890".data(using: String.Encoding.ascii)!
-        let times: [TimeInterval] = [1111111111, 1234567890, 2000000000]
+        let timesSinceEpoch: [TimeInterval] = [1111111111, 1234567890, 2000000000]
 
         let expectedValues: [Generator.Algorithm: [String]] = [
             .sha1:   ["050471", "005924", "279037"],
@@ -275,12 +274,11 @@ class GeneratorTests: XCTestCase {
 
         for (algorithm, expectedPasswords) in expectedValues {
             let generator = Generator(factor: .timer(period: 30), secret: secret, algorithm: algorithm, digits: 6)
-            for i in 0..<times.count {
-                let expectedPassword = expectedPasswords[i]
-                let time = Date(timeIntervalSince1970: times[i])
+            for (timeSinceEpoch, expectedPassword) in zip(timesSinceEpoch, expectedPasswords) {
+                let time = Date(timeIntervalSince1970: timeSinceEpoch)
                 let password = generator.flatMap { try? $0.password(at: time) }
                 XCTAssertEqual(password, expectedPassword,
-                    "Incorrect result for \(algorithm) at \(times[i])")
+                    "Incorrect result for \(algorithm) at \(timeSinceEpoch)")
             }
         }
     }

--- a/Tests/TokenTests.swift
+++ b/Tests/TokenTests.swift
@@ -122,10 +122,10 @@ class TokenTests: XCTestCase {
         let timerToken = Token(generator: timerGenerator)
 
         do {
-            let password = try timerToken.generator.password(at: Date().timeIntervalSince1970)
+            let password = try timerToken.generator.password(at: Date())
             XCTAssertEqual(timerToken.currentPassword, password)
 
-            let oldPassword = try timerToken.generator.password(at: 0)
+            let oldPassword = try timerToken.generator.password(at: Date(timeIntervalSince1970: 0))
             XCTAssertNotEqual(timerToken.currentPassword, oldPassword)
         } catch {
             XCTFail()
@@ -144,10 +144,10 @@ class TokenTests: XCTestCase {
         let counterToken = Token(generator: counterGenerator)
 
         do {
-            let password = try counterToken.generator.password(at: Date().timeIntervalSince1970)
+            let password = try counterToken.generator.password(at: Date())
             XCTAssertEqual(counterToken.currentPassword, password)
 
-            let oldPassword = try counterToken.generator.password(at: 0)
+            let oldPassword = try counterToken.generator.password(at: Date(timeIntervalSince1970: 0))
             XCTAssertEqual(counterToken.currentPassword, oldPassword)
         } catch {
             XCTFail()


### PR DESCRIPTION
The user of OneTimePassword is more likely to already have a `Date` than they are to have a `TimeInterval` since the Unix epoch. An API using a `Date` is more clear, since using a `TimeInterval` requires knowledge of the base date from which the time interval is measured.