### PR TITLE
SwiftLint 0.22

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,6 +25,7 @@ disabled_rules:
   - cyclomatic_complexity
   - function_body_length
   - syntactic_sugar
+  - xctfail_message
 
 trailing_comma:
   mandatory_comma: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,7 @@ opt_in_rules:
   - implicitly_unwrapped_optional
   - joined_default_parameter
   - let_var_whitespace
+  - multiline_parameters
   - nimble_operator
   - operator_usage_whitespace
   - overridden_super_call
@@ -40,6 +41,7 @@ trailing_comma:
 
 line_length:
   warning: 120
+  ignores_function_declarations: true
 
 file_header:
   required_pattern: |

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -34,7 +34,6 @@ disabled_rules:
   - cyclomatic_complexity
   - function_body_length
   - syntactic_sugar
-  - xctfail_message
 
 trailing_comma:
   mandatory_comma: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,15 +9,23 @@ opt_in_rules:
   - conditional_returns_on_newline
   - empty_count
   - explicit_init
+  - fatal_error_message
   - file_header
   - first_where
+  - implicit_return
+  - implicitly_unwrapped_optional
+  - joined_default_parameter
+  - let_var_whitespace
   - nimble_operator
   - operator_usage_whitespace
   - overridden_super_call
+  - pattern_matching_keywords
   - private_outlet
   - prohibited_super_call
   - redundant_nil_coalescing
+  - single_test_class
   - switch_case_on_newline
+  - unneeded_parentheses_in_closure_argument
   - vertical_whitespace
 disabled_rules:
   - colon

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -11,7 +11,6 @@ opt_in_rules:
   - explicit_init
   - file_header
   - first_where
-#  - missing_docs
   - nimble_operator
   - operator_usage_whitespace
   - overridden_super_call
@@ -26,7 +25,6 @@ disabled_rules:
   - cyclomatic_complexity
   - function_body_length
   - syntactic_sugar
-  - valid_docs
 
 trailing_comma:
   mandatory_comma: true

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -98,8 +98,7 @@ private func algorithmFromString(_ string: String) -> Generator.Algorithm? {
     }
 }
 
-private func urlForToken(name: String, issuer: String, factor: Generator.Factor, algorithm: Generator.Algorithm,
-                         digits: Int) throws -> URL {
+private func urlForToken(name: String, issuer: String, factor: Generator.Factor, algorithm: Generator.Algorithm, digits: Int) throws -> URL {
     var urlComponents = URLComponents()
     urlComponents.scheme = kOTPAuthScheme
     urlComponents.path = "/" + name
@@ -200,8 +199,7 @@ private func token(from url: URL, secret externalSecret: Data? = nil) -> Token? 
     return Token(name: name, issuer: issuer, generator: generator)
 }
 
-private func parse<P, T>(_ item: P?, with parser: ((P) -> T?), defaultTo defaultValue: T? = nil,
-                         overrideWith overrideValue: T? = nil) -> T? {
+private func parse<P, T>(_ item: P?, with parser: ((P) -> T?), defaultTo defaultValue: T? = nil, overrideWith overrideValue: T? = nil) -> T? {
     if let value = overrideValue {
         return value
     }

--- a/Tests/EquatableTests.swift
+++ b/Tests/EquatableTests.swift
@@ -68,7 +68,7 @@ class EquatableTests: XCTestCase {
     func testTokenEquality() {
         guard let generator = Generator(factor: .counter(0), secret: Data(), algorithm: .sha1, digits: 6),
             let other_generator = Generator(factor: .counter(1), secret: Data(), algorithm: .sha512, digits: 8) else {
-                XCTFail()
+                XCTFail("Failed to construct Generator.")
                 return
         }
 

--- a/Tests/TokenSerializationTests.swift
+++ b/Tests/TokenSerializationTests.swift
@@ -64,7 +64,7 @@ class TokenSerializationTests: XCTestCase {
                                     algorithm: algorithm,
                                     digits: digitNumber
                                 ) else {
-                                    XCTFail()
+                                    XCTFail("Failed to construct Generator.")
                                     continue
                                 }
 

--- a/Tests/TokenTests.swift
+++ b/Tests/TokenTests.swift
@@ -40,7 +40,7 @@ class TokenTests: XCTestCase {
             algorithm: .sha1,
             digits: 6
         ) else {
-            XCTFail()
+            XCTFail("Failed to construct Generator.")
             return
         }
 
@@ -63,7 +63,7 @@ class TokenTests: XCTestCase {
             algorithm: .sha512,
             digits: 8
         ) else {
-            XCTFail()
+            XCTFail("Failed to construct Generator.")
             return
         }
 
@@ -90,7 +90,7 @@ class TokenTests: XCTestCase {
             algorithm: .sha1,
             digits: 6
         ) else {
-            XCTFail()
+            XCTFail("Failed to construct Generator.")
             return
         }
         let n = "Test Name"
@@ -116,7 +116,7 @@ class TokenTests: XCTestCase {
             algorithm: .sha1,
             digits: 6
         ) else {
-            XCTFail()
+            XCTFail("Failed to construct Generator.")
             return
         }
         let timerToken = Token(generator: timerGenerator)
@@ -128,7 +128,7 @@ class TokenTests: XCTestCase {
             let oldPassword = try timerToken.generator.password(at: Date(timeIntervalSince1970: 0))
             XCTAssertNotEqual(timerToken.currentPassword, oldPassword)
         } catch {
-            XCTFail()
+            XCTFail("Failed to generate password with error: \(error)")
             return
         }
 
@@ -138,7 +138,7 @@ class TokenTests: XCTestCase {
             algorithm: .sha1,
             digits: 6
         ) else {
-            XCTFail()
+            XCTFail("Failed to construct Generator.")
             return
         }
         let counterToken = Token(generator: counterGenerator)
@@ -150,7 +150,7 @@ class TokenTests: XCTestCase {
             let oldPassword = try counterToken.generator.password(at: Date(timeIntervalSince1970: 0))
             XCTAssertEqual(counterToken.currentPassword, oldPassword)
         } catch {
-            XCTFail()
+            XCTFail("Failed to generate password with error: \(error)")
             return
         }
     }
@@ -162,7 +162,7 @@ class TokenTests: XCTestCase {
             algorithm: .sha1,
             digits: 6
         ) else {
-            XCTFail()
+            XCTFail("Failed to construct Generator.")
             return
         }
         let timerToken = Token(generator: timerGenerator)
@@ -177,7 +177,7 @@ class TokenTests: XCTestCase {
             algorithm: .sha1,
             digits: 6
         ) else {
-            XCTFail()
+            XCTFail("Failed to construct Generator.")
             return
         }
         let counterToken = Token(generator: counterGenerator)


### PR DESCRIPTION
- Remove several outdated SwiftLint rules and add many new opt-in rules.
- Allow function declarations to exceed the normal line length limit.
- Include error messages in all calls to `XCTFail()`.