### PR TITLE
Refactor token URL parsing

### DIFF
--- a/OneTimePasswordLegacyTests/OTPTokenSerializationTests.m
+++ b/OneTimePasswordLegacyTests/OTPTokenSerializationTests.m
@@ -372,9 +372,11 @@ static const unsigned char kValidSecret[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05
 {
     NSArray *badURLs = @[@"http://foo", // invalid scheme
                          @"otpauth://foo", // invalid type
+                         @"otpauth:///bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4", // missing type
                          @"otpauth://totp/bar", // missing secret
                          @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&period=0", // invalid period
                          @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&period=x", // non-numeric period
+                         @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&period=30&period=60", // multiple period
                          @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&algorithm=MD5", // invalid algorithm
                          @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&digits=2", // invalid digits
                          @"otpauth://totp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4&digits=x", // non-numeric digits

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -199,11 +199,21 @@ private func token(from url: URL, secret externalSecret: Data? = nil) -> Token? 
     return Token(name: name, issuer: issuer, generator: generator)
 }
 
-private func parse<P, T>(_ item: P?, with parser: ((P) -> T?), defaultTo defaultValue: T? = nil, overrideWith overrideValue: T? = nil) -> T? {
+private func parse<P, T>(_ item: P?, with parser: ((P) -> T?), overrideWith overrideValue: T?) -> T? {
     if let value = overrideValue {
         return value
     }
 
+    if let concrete = item {
+        guard let value = parser(concrete) else {
+            return nil
+        }
+        return value
+    }
+    return nil
+}
+
+private func parse<P, T>(_ item: P?, with parser: ((P) -> T?), defaultTo defaultValue: T?) -> T? {
     if let concrete = item {
         guard let value = parser(concrete) else {
             return nil

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -164,8 +164,7 @@ private func token(from url: URL, secret externalSecret: Data? = nil) throws -> 
     let digits = try queryDictionary[kQueryDigitsKey].map(parseDigits) ?? defaultDigits
 
     guard let factor = try url.host.map(factorParser),
-        let secret = try parse(queryDictionary[kQuerySecretKey], with: parseSecret,
-                           overrideWith: externalSecret),
+        let secret = try externalSecret ?? queryDictionary[kQuerySecretKey].map(parseSecret),
         let generator = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits) else {
             return nil
     }
@@ -222,16 +221,4 @@ private func parseDigits(_ rawValue: String) throws -> Int {
         throw DeserializationError.digits
     }
     return intValue
-}
-
-private func parse<P, T>(_ item: P?, with parser: ((P) throws -> T), overrideWith overrideValue: T?) rethrows -> T? {
-    if let value = overrideValue {
-        return value
-    }
-
-    if let concrete = item {
-        let value = try parser(concrete)
-        return value
-    }
-    return nil
 }

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -146,6 +146,7 @@ private func token(from url: URL, secret externalSecret: Data? = nil) throws -> 
 
     var queryDictionary = Dictionary<String, String>()
     URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?.forEach { item in
+        // TODO: guard against duplicate query items for the same key.
         queryDictionary[item.name] = item.value
     }
 

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -56,6 +56,7 @@ internal enum SerializationError: Swift.Error {
 
 internal enum DeserializationError: Swift.Error {
     case invalidURLScheme
+    case duplicateQueryItem(String)
     case missingFactor
     case invalidFactor(String)
     case invalidCounterValue(String)
@@ -144,19 +145,15 @@ private func token(from url: URL, secret externalSecret: Data? = nil) throws -> 
         throw DeserializationError.invalidURLScheme
     }
 
-    var queryDictionary = Dictionary<String, String>()
-    URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?.forEach { item in
-        // TODO: guard against duplicate query items for the same key.
-        queryDictionary[item.name] = item.value
-    }
+    let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
 
     let factor: Generator.Factor
     switch url.host {
     case .some(kFactorCounterKey):
-        let counterValue = try queryDictionary[kQueryCounterKey].map(parseCounterValue) ?? defaultCounter
+        let counterValue = try queryItems.value(for: kQueryCounterKey).map(parseCounterValue) ?? defaultCounter
         factor = .counter(counterValue)
     case .some(kFactorTimerKey):
-        let period = try queryDictionary[kQueryPeriodKey].map(parseTimerPeriod) ?? defaultPeriod
+        let period = try queryItems.value(for: kQueryPeriodKey).map(parseTimerPeriod) ?? defaultPeriod
         factor = .timer(period: period)
     case let .some(rawValue):
         throw DeserializationError.invalidFactor(rawValue)
@@ -164,9 +161,9 @@ private func token(from url: URL, secret externalSecret: Data? = nil) throws -> 
         throw DeserializationError.missingFactor
     }
 
-    let algorithm = try queryDictionary[kQueryAlgorithmKey].map(algorithmFromString) ?? defaultAlgorithm
-    let digits = try queryDictionary[kQueryDigitsKey].map(parseDigits) ?? defaultDigits
-    guard let secret = try externalSecret ?? queryDictionary[kQuerySecretKey].map(parseSecret) else {
+    let algorithm = try queryItems.value(for: kQueryAlgorithmKey).map(algorithmFromString) ?? defaultAlgorithm
+    let digits = try queryItems.value(for: kQueryDigitsKey).map(parseDigits) ?? defaultDigits
+    guard let secret = try externalSecret ?? queryItems.value(for: kQuerySecretKey).map(parseSecret) else {
         throw DeserializationError.missingSecret
     }
     guard let generator = Generator(factor: factor, secret: secret, algorithm: algorithm, digits: digits) else {
@@ -178,7 +175,7 @@ private func token(from url: URL, secret externalSecret: Data? = nil) throws -> 
     var name = String(url.path.dropFirst())
 
     let issuer: String
-    if let issuerString = queryDictionary[kQueryIssuerKey] {
+    if let issuerString = try queryItems.value(for: kQueryIssuerKey) {
         issuer = issuerString
     } else if let separatorRange = name.range(of: ":") {
         // If there is no issuer string, try to extract one from the name
@@ -226,4 +223,16 @@ private func parseDigits(_ rawValue: String) throws -> Int {
         throw DeserializationError.invalidDigits(rawValue)
     }
     return digits
+}
+
+extension Array where Element == URLQueryItem {
+    func value(for name: String) throws -> String? {
+        let matchingQueryItems = self.filter({
+            $0.name == name
+        })
+        guard matchingQueryItems.count <= 1 else {
+            throw DeserializationError.duplicateQueryItem(name)
+        }
+        return matchingQueryItems.first?.value
+    }
 }

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -208,22 +208,22 @@ private func parseCounterValue(_ rawValue: String) throws -> UInt64 {
 }
 
 private func parseTimerPeriod(_ rawValue: String) throws -> TimeInterval {
-    guard let int = Int(rawValue) else {
+    guard let period = TimeInterval(rawValue) else {
         throw DeserializationError.invalidTimerPeriod(rawValue)
     }
-    return TimeInterval(int)
+    return period
 }
 
 private func parseSecret(_ rawValue: String) throws -> Data {
-    guard let data = MF_Base32Codec.data(fromBase32String: rawValue) else {
+    guard let secret = MF_Base32Codec.data(fromBase32String: rawValue) else {
         throw DeserializationError.invalidSecret(rawValue)
     }
-    return data
+    return secret
 }
 
 private func parseDigits(_ rawValue: String) throws -> Int {
-    guard let intValue = Int(rawValue) else {
+    guard let digits = Int(rawValue) else {
         throw DeserializationError.invalidDigits(rawValue)
     }
-    return intValue
+    return digits
 }

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -154,8 +154,8 @@ private func token(from url: URL, secret externalSecret: Data? = nil) throws -> 
     let factor: Generator.Factor
     switch url.host {
     case .some(kFactorCounterKey):
-        let counter = try queryDictionary[kQueryCounterKey].map(parseCounterValue) ?? defaultCounter
-        factor = .counter(counter)
+        let counterValue = try queryDictionary[kQueryCounterKey].map(parseCounterValue) ?? defaultCounter
+        factor = .counter(counterValue)
     case .some(kFactorTimerKey):
         let period = try queryDictionary[kQueryPeriodKey].map(parseTimerPeriod) ?? defaultPeriod
         factor = .timer(period: period)

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -151,18 +151,18 @@ private func token(from url: URL, secret externalSecret: Data? = nil) throws -> 
         queryDictionary[item.name] = item.value
     }
 
-    guard let factorString = url.host else {
-        throw DeserializationError.missingFactor
-    }
     let factor: Generator.Factor
-    if factorString == kFactorCounterKey {
+    switch url.host {
+    case .some(kFactorCounterKey):
         let counter = try queryDictionary[kQueryCounterKey].map(parseCounterValue) ?? defaultCounter
         factor = .counter(counter)
-    } else if factorString == kFactorTimerKey {
+    case .some(kFactorTimerKey):
         let period = try queryDictionary[kQueryPeriodKey].map(parseTimerPeriod) ?? defaultPeriod
         factor = .timer(period: period)
-    } else {
-        throw DeserializationError.invalidFactor(factorString)
+    case let .some(rawValue):
+        throw DeserializationError.invalidFactor(rawValue)
+    case .none:
+        throw DeserializationError.missingFactor
     }
 
     let algorithm = try queryDictionary[kQueryAlgorithmKey].map(algorithmFromString) ?? defaultAlgorithm

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -139,23 +139,13 @@ private func token(from url: URL, secret externalSecret: Data? = nil) -> Token? 
     let factorParser: (String) -> Generator.Factor? = { string in
         if string == kFactorCounterKey {
             if let counter: UInt64 = parse(queryDictionary[kQueryCounterKey],
-                with: {
-                    guard let counterValue = UInt64($0, radix: 10) else {
-                        return nil
-                    }
-                    return counterValue
-                },
+                with: parseCounterValue,
                 defaultTo: defaultCounter) {
                     return .counter(counter)
             }
         } else if string == kFactorTimerKey {
             if let period: TimeInterval = parse(queryDictionary[kQueryPeriodKey],
-                with: {
-                    guard let int = Int($0) else {
-                        return nil
-                    }
-                    return TimeInterval(int)
-                },
+                with: parseTimerPeriod,
                 defaultTo: defaultPeriod) {
                     return .timer(period: period)
             }
@@ -197,6 +187,20 @@ private func token(from url: URL, secret externalSecret: Data? = nil) -> Token? 
     }
 
     return Token(name: name, issuer: issuer, generator: generator)
+}
+
+private func parseCounterValue(_ rawValue: String) -> UInt64? {
+    guard let counterValue = UInt64(rawValue, radix: 10) else {
+        return nil
+    }
+    return counterValue
+}
+
+private func parseTimerPeriod(_ rawValue: String) -> TimeInterval? {
+    guard let int = Int(rawValue) else {
+        return nil
+    }
+    return TimeInterval(int)
 }
 
 private func parse<P, T>(_ item: P?, with parser: ((P) -> T?), overrideWith overrideValue: T?) -> T? {

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -203,7 +203,7 @@ private func token(from url: URL, secret externalSecret: Data? = nil) throws -> 
 }
 
 private func parseCounterValue(_ rawValue: String) throws -> UInt64 {
-    guard let counterValue = UInt64(rawValue, radix: 10) else {
+    guard let counterValue = UInt64(rawValue) else {
         throw DeserializationError.invalidCounterValue(rawValue)
     }
     return counterValue

--- a/Tests/TokenSerializationTests.swift
+++ b/Tests/TokenSerializationTests.swift
@@ -162,4 +162,17 @@ class TokenSerializationTests: XCTestCase {
             }
         }
     }
+
+    func testTokenWithDefaultCounter() {
+        let tokenURLString = "otpauth://hotp/bar?secret=AAAQEAYEAUDAOCAJBIFQYDIOB4"
+        guard let tokenURL = URL(string: tokenURLString) else {
+            XCTFail("Failed to initialize a URL from String \"\(tokenURLString)\"")
+            return
+        }
+        guard let token = Token(url: tokenURL) else {
+            XCTFail("Failed to initialize a Token from URL \"\(tokenURL)\"")
+            return
+        }
+        XCTAssertEqual(token.generator.factor, .counter(0))
+    }
 }


### PR DESCRIPTION
Refactor the parsing of URL into Token, replacing the complex generic parsing helper with dedicated throwing helper methods and an overall more functional, decomposed structure. Also, improve testing of several parsing edge cases.