### PR TITLE
Upgrade Base32

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 # Configuration for Carthage (https://github.com/Carthage/Carthage)
 
-github "mattrubin/Base32" "1.1.2+carthage"
+github "mattrubin/Base32" "24f64bf81b15c815019f37cf64cfbb3a253e2bea"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "jspahrsummers/xcconfigs" "0.11"
-github "mattrubin/Base32" "1.1.2+carthage"
+github "mattrubin/Base32" "24f64bf81b15c815019f37cf64cfbb3a253e2bea"


### PR DESCRIPTION
Upgrade Base32 to an intermediate version configured for Xcode 9