### PR TITLE
Update SwiftLint configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,10 +3,12 @@
 excluded:
   - Carthage
 opt_in_rules:
+  - array_init
   - attributes
   - closure_end_indentation
   - closure_spacing
   - conditional_returns_on_newline
+  - contains_over_first_not_nil
   - empty_count
   - explicit_init
   - fatal_error_message
@@ -20,11 +22,13 @@ opt_in_rules:
   - nimble_operator
   - operator_usage_whitespace
   - overridden_super_call
+  - override_in_extension
   - pattern_matching_keywords
   - private_outlet
   - prohibited_super_call
   - redundant_nil_coalescing
   - single_test_class
+  - sorted_first_last
   - switch_case_on_newline
   - unneeded_parentheses_in_closure_argument
   - vertical_whitespace

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -31,7 +31,6 @@ opt_in_rules:
   - sorted_first_last
   - switch_case_on_newline
   - unneeded_parentheses_in_closure_argument
-  - vertical_whitespace
 disabled_rules:
   - colon
   - comma

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,6 +20,7 @@ opt_in_rules:
   - implicitly_unwrapped_optional
   - joined_default_parameter
   - let_var_whitespace
+  - literal_expression_end_indentation
   - multiline_parameters
   - nimble_operator
   - operator_usage_whitespace

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,7 +44,6 @@ trailing_comma:
   mandatory_comma: true
 
 line_length:
-  warning: 120
   ignores_function_declarations: true
 
 file_header:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ opt_in_rules:
   - conditional_returns_on_newline
   - contains_over_first_not_nil
   - empty_count
+  - explicit_enum_raw_value
   - explicit_init
   - fatal_error_message
   - file_header

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -39,7 +39,6 @@ disabled_rules:
   - comma
   - cyclomatic_complexity
   - function_body_length
-  - syntactic_sugar
 
 trailing_comma:
   mandatory_comma: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,6 +12,7 @@ opt_in_rules:
   - empty_count
   - explicit_enum_raw_value
   - explicit_init
+  - extension_access_modifier
   - fatal_error_message
   - file_header
   - first_where

--- a/OneTimePasswordLegacyTests/OTPToken.swift
+++ b/OneTimePasswordLegacyTests/OTPToken.swift
@@ -102,6 +102,7 @@ public extension OTPToken {
 
 // MARK: Enums
 
+// swiftlint:disable explicit_enum_raw_value
 @objc
 public enum OTPTokenType: UInt8 {
     case counter
@@ -114,6 +115,7 @@ public enum OTPAlgorithm: UInt32 {
     @objc(OTPAlgorithmSHA256) case sha256
     @objc(OTPAlgorithmSHA512) case sha512
 }
+// swiftlint:enable explicit_enum_raw_value
 
 // MARK: Conversion
 

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -26,11 +26,11 @@
 import Foundation
 import Base32
 
-extension Token {
+public extension Token {
     // MARK: Serialization
 
     /// Serializes the token to a URL.
-    public func toURL() throws -> URL {
+    func toURL() throws -> URL {
         return try urlForToken(
             name: name,
             issuer: issuer,
@@ -41,7 +41,7 @@ extension Token {
     }
 
     /// Attempts to initialize a token represented by the give URL.
-    public init?(url: URL, secret: Data? = nil) {
+    init?(url: URL, secret: Data? = nil) {
         do {
             self = try token(from: url, secret: secret)
         } catch {

--- a/Tests/TokenSerializationTests.swift
+++ b/Tests/TokenSerializationTests.swift
@@ -100,7 +100,7 @@ class TokenSerializationTests: XCTestCase {
                                 XCTAssertEqual(items?.count, expectedItemCount,
                                                "There shouldn't be any unexpected query arguments: \(url)")
 
-                                var queryArguments = Dictionary<String, String>()
+                                var queryArguments: [String: String] = [:]
                                 for item in items ?? [] {
                                     queryArguments[item.name] = item.value
                                 }


### PR DESCRIPTION
- Enable several new opt-in rules for SwiftLint 0.24
- Remove explicit opt-in for the enabled-by-default `vertical_whitespace` rule
- Re-enable the `syntactic_sugar` rule
- Use the default line length warning threshold