### PR TITLE
Update SwiftLint configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,7 +42,6 @@ disabled_rules:
   - colon
   - comma
   - cyclomatic_complexity
-  - function_body_length
 
 trailing_comma:
   mandatory_comma: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,8 @@ opt_in_rules:
   - closure_spacing
   - conditional_returns_on_newline
   - contains_over_first_not_nil
+  - discouraged_object_literal
+  - discouraged_optional_boolean
   - empty_count
   - explicit_enum_raw_value
   - explicit_init
@@ -34,6 +36,7 @@ opt_in_rules:
   - sorted_first_last
   - switch_case_on_newline
   - unneeded_parentheses_in_closure_argument
+  - yoda_condition
 disabled_rules:
   - colon
   - comma

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -36,6 +36,7 @@ opt_in_rules:
   - sorted_first_last
   - switch_case_on_newline
   - unneeded_parentheses_in_closure_argument
+  - vertical_parameter_alignment_on_call
   - yoda_condition
 disabled_rules:
   - colon

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -74,7 +74,7 @@ public final class Keychain {
     public func update(_ persistentToken: PersistentToken, with token: Token) throws -> PersistentToken {
         let attributes = try token.keychainAttributes()
         try updateKeychainItem(forPersistentRef: persistentToken.identifier,
-            withAttributes: attributes)
+                               withAttributes: attributes)
         return PersistentToken(token: token, identifier: persistentToken.identifier)
     }
 

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -90,7 +90,7 @@ class GeneratorTests: XCTestCase {
             let totp = Generator(factor: timer, secret: secret, algorithm: .sha1, digits: 6)
                 .flatMap { try? $0.password(at: time) }
             XCTAssertEqual(hotp, totp,
-                "TOTP with \(timer) should match HOTP with counter \(counter) at time \(time).")
+                           "TOTP with \(timer) should match HOTP with counter \(counter) at time \(time).")
         }
     }
 
@@ -226,7 +226,7 @@ class GeneratorTests: XCTestCase {
             let time = Date(timeIntervalSince1970: 0)
             let password = generator.flatMap { try? $0.password(at: time) }
             XCTAssertEqual(password, expectedPassword,
-                "The generator did not produce the expected OTP.")
+                           "The generator did not produce the expected OTP.")
         }
     }
 
@@ -255,7 +255,7 @@ class GeneratorTests: XCTestCase {
                 let time = Date(timeIntervalSince1970: timeSinceEpoch)
                 let password = generator.flatMap { try? $0.password(at: time) }
                 XCTAssertEqual(password, expectedPassword,
-                    "Incorrect result for \(algorithm) at \(timeSinceEpoch)")
+                               "Incorrect result for \(algorithm) at \(timeSinceEpoch)")
             }
         }
     }
@@ -278,7 +278,7 @@ class GeneratorTests: XCTestCase {
                 let time = Date(timeIntervalSince1970: timeSinceEpoch)
                 let password = generator.flatMap { try? $0.password(at: time) }
                 XCTAssertEqual(password, expectedPassword,
-                    "Incorrect result for \(algorithm) at \(timeSinceEpoch)")
+                               "Incorrect result for \(algorithm) at \(timeSinceEpoch)")
             }
         }
     }

--- a/Tests/KeychainTests.swift
+++ b/Tests/KeychainTests.swift
@@ -101,6 +101,7 @@ class KeychainTests: XCTestCase {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     func testDuplicateTokens() {
         let token1 = testToken, token2 = testToken
 

--- a/Tests/TokenSerializationTests.swift
+++ b/Tests/TokenSerializationTests.swift
@@ -50,6 +50,7 @@ class TokenSerializationTests: XCTestCase {
     let algorithms: [OneTimePassword.Generator.Algorithm] = [.sha1, .sha256, .sha512]
     let digits = [6, 7, 8]
 
+    // swiftlint:disable:next function_body_length
     func testSerialization() {
         for factor in factors {
             for name in names {

--- a/Tests/TokenSerializationTests.swift
+++ b/Tests/TokenSerializationTests.swift
@@ -97,8 +97,12 @@ class TokenSerializationTests: XCTestCase {
                                 let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
                                 let items = urlComponents?.queryItems
                                 let expectedItemCount = 4
+                                // SwiftLint gives a false positive here because of a Swift/SourceKit bug.
+                                // See https://github.com/realm/SwiftLint/issues/1785
+                                // swiftlint:disable vertical_parameter_alignment_on_call
                                 XCTAssertEqual(items?.count, expectedItemCount,
                                                "There shouldn't be any unexpected query arguments: \(url)")
+                                // swiftlint:enable vertical_parameter_alignment_on_call
 
                                 var queryArguments: [String: String] = [:]
                                 for item in items ?? [] {


### PR DESCRIPTION
Enable more SwiftLint rules, adding a few targeted exceptions and fixing parameter alignment in several places. 