### PR TITLE
More reliable Base32 dependency version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 # Configuration for Carthage (https://github.com/Carthage/Carthage)
 
-github "mattrubin/Base32" "24f64bf81b15c815019f37cf64cfbb3a253e2bea"
+github "mattrubin/Base32" "xcode9"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "jspahrsummers/xcconfigs" "0.11"
-github "mattrubin/Base32" "24f64bf81b15c815019f37cf64cfbb3a253e2bea"
+github "mattrubin/Base32" "xcode9"


### PR DESCRIPTION
Update the Cartfile to depend on a tagged version of Base32, rather than a specific commit hash.