### PR TITLE
Keychain Deserialization Errors

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,10 @@ codecov:
 ignore:
   - Tests
   - OneTimePasswordLegacyTests
+
+coverage:
+  status:
+    patch:
+      default:
+        # Allow patch to be 0% covered without marking a PR with a failing status.
+        target: 0

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -141,7 +141,7 @@ private extension PersistentToken {
             throw DeserializationError.missingPersistentRef
         }
         guard let urlString = String(data: urlData, encoding: urlStringEncoding),
-            let url = URL(string: urlString as String) else {
+            let url = URL(string: urlString) else {
                 throw DeserializationError.unreadableData
         }
         let token = try Token(_url: url, secret: secret)

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -129,7 +129,7 @@ private extension PersistentToken {
             let secret = keychainDictionary[kSecValueData as String] as? Data,
             let keychainItemRef = keychainDictionary[kSecValuePersistentRef as String] as? Data,
             let url = URL(string: urlString as String),
-            let token = Token(url: url, secret: secret) else {
+            let token = try? Token(_url: url, secret: secret) else {
                 return nil
         }
         self.init(token: token, identifier: keychainItemRef)

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -48,6 +48,10 @@ extension Token {
             return nil
         }
     }
+
+    internal init(_url url: URL, secret: Data? = nil) throws {
+        self = try token(from: url, secret: secret)
+    }
 }
 
 internal enum SerializationError: Swift.Error {

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -42,13 +42,13 @@ public extension Token {
 
     /// Attempts to initialize a token represented by the give URL.
     init?(url: URL, secret: Data? = nil) {
-        do {
-            self = try token(from: url, secret: secret)
-        } catch {
-            return nil
-        }
+        try? self.init(_url: url, secret: secret)
     }
 
+    // Eventually, this throwing initializer will replace the failable initializer above. For now, the failable
+    // initializer remains to maintain a consistent public API. Since two different initializers cannot overload the
+    // same initializer signature with both throwing an failable versions, this new initializer is currently prefixed
+    // with an underscore and marked as internal.
     internal init(_url url: URL, secret: Data? = nil) throws {
         self = try token(from: url, secret: secret)
     }

--- a/Tests/KeychainTests.swift
+++ b/Tests/KeychainTests.swift
@@ -257,7 +257,7 @@ class KeychainTests: XCTestCase {
 
         let persistentRef = try addKeychainItem(withAttributes: keychainAttributes)
 
-        XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef), "") { error in print(error) }
+        XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef))
         XCTAssertThrowsError(try keychain.allPersistentTokens())
     }
 
@@ -271,7 +271,7 @@ class KeychainTests: XCTestCase {
 
         let persistentRef = try addKeychainItem(withAttributes: keychainAttributes)
 
-        XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef), "") { error in print(error) }
+        XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef))
         XCTAssertThrowsError(try keychain.allPersistentTokens())
     }
 


### PR DESCRIPTION
Add an internal throwing initializer for creating a Token from a url, and convert the failable initializer for creating a PersistentToken from a keychain dictionary to a throwing initializer.

This fixes an issue in `persistentToken(withIdentifier:)` and `allPersistentTokens()` where deserialization errors would be ignored, causing a persistent token that existed but could not be deserialized to be treated the same as a persistent token that did not exist.