### PR TITLE
CodeCov Configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,9 @@
 # Configuration for Codecov (https://codecov.io)
 
+codecov:
+  # Use `develop` as the default branch
+  branch: develop
+
 ignore:
   - Tests
   - OneTimePasswordLegacyTests

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,5 @@
 # Configuration for Codecov (https://codecov.io)
 
-coverage:
-  ignore:
-    - "Tests"
-    - "OneTimePasswordLegacyTests"
+ignore:
+  - Tests
+  - OneTimePasswordLegacyTests


### PR DESCRIPTION
Configure CodeCov to use `develop` as the default branch, and clean up the `ignore` list.