### PR TITLE
Use conditional compilation to handle changes to UnsafeMutablePointer deallocate API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [In development][develop]
 
 - Update build and linter settings for Xcode 9.3. ([#167](https://github.com/mattrubin/OneTimePassword/pull/167))
+- Use conditional compilation to handle SE-0184 changes to the UnsafeMutablePointer `deallocate` API. ([#168](https://github.com/mattrubin/OneTimePassword/pull/168))
 
 
 ## [3.1][] (2018-03-27)

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -30,7 +30,13 @@ func HMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
     let (hashFunction, hashLength) = algorithm.hashInfo
 
     let macOut = UnsafeMutablePointer<UInt8>.allocate(capacity: hashLength)
-    defer { macOut.deallocate(capacity: hashLength) }
+    defer {
+        #if swift(>=4.1)
+        macOut.deallocate()
+        #else
+        macOut.deallocate(capacity: hashLength)
+        #endif
+    }
 
     key.withUnsafeBytes { keyBytes in
         data.withUnsafeBytes { dataBytes in


### PR DESCRIPTION
Fixes https://github.com/mattrubin/OneTimePassword/issues/166