### PR TITLE
Release OneTimePassword 3.1.1

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,6 +42,7 @@ disabled_rules:
   - colon
   - comma
   - cyclomatic_complexity
+  - identifier_name
 
 trailing_comma:
   mandatory_comma: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [In development][develop]
 
 - Update build and linter settings for Xcode 9.3. ([#167](https://github.com/mattrubin/OneTimePassword/pull/167))
+- Use conditional compilation to handle SE-0184 changes to the UnsafeMutablePointer `deallocate` API. ([#168](https://github.com/mattrubin/OneTimePassword/pull/168))
 
 
 ## [3.1][] (2018-03-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # OneTimePassword Changelog
 
-## [In development][develop]
+<!--## [In development][develop]-->
 
+## [3.1.1][] (2018-03-31)
 - Update build and linter settings for Xcode 9.3. ([#167](https://github.com/mattrubin/OneTimePassword/pull/167))
-- Use conditional compilation to handle SE-0184 changes to the UnsafeMutablePointer `deallocate` API. ([#168](https://github.com/mattrubin/OneTimePassword/pull/168))
+- Use conditional compilation to handle Swift 4.1 changes to the UnsafeMutablePointer `deallocate` API. ([#168](https://github.com/mattrubin/OneTimePassword/pull/168))
 
 
 ## [3.1][] (2018-03-27)
@@ -147,8 +148,9 @@ Changes between prerelease versions of OneTimePassword version 2 can be found be
 
 ## [1.0.0][] (2014-07-17)
 
-[develop]: https://github.com/mattrubin/OneTimePassword/compare/3.1...develop
+[develop]: https://github.com/mattrubin/OneTimePassword/compare/3.1.1...develop
 
+[3.1.1]: https://github.com/mattrubin/OneTimePassword/compare/3.1...3.1.1
 [3.1]: https://github.com/mattrubin/OneTimePassword/compare/3.0.1...3.1
 [3.0.1]: https://github.com/mattrubin/OneTimePassword/compare/3.0...3.0.1
 [3.0]: https://github.com/mattrubin/OneTimePassword/compare/2.1.1...3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 <!--## [In development][develop]-->
 
 ## [3.1.1][] (2018-03-31)
+- Add support for Swift 4.1. ([#168](https://github.com/mattrubin/OneTimePassword/pull/168))
 - Update build and linter settings for Xcode 9.3. ([#167](https://github.com/mattrubin/OneTimePassword/pull/167))
-- Use conditional compilation to handle Swift 4.1 changes to the UnsafeMutablePointer `deallocate` API. ([#168](https://github.com/mattrubin/OneTimePassword/pull/168))
 
 
 ## [3.1][] (2018-03-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # OneTimePassword Changelog
 
-<!--## [In development][develop]-->
+## [In development][develop]
+
+- Update build and linter settings for Xcode 9.3. ([#167](https://github.com/mattrubin/OneTimePassword/pull/167))
+
 
 ## [3.1][] (2018-03-27)
 - Upgrade to Swift 4 and Xcode 9.

--- a/OneTimePassword.podspec
+++ b/OneTimePassword.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "OneTimePassword"
-  s.version      = "3.1"
+  s.version      = "3.1.1"
   s.summary      = "A small library for generating TOTP and HOTP one-time passwords."
   s.homepage     = "https://github.com/mattrubin/OneTimePassword"
   s.license      = "MIT"

--- a/OneTimePassword.xcodeproj/project.pbxproj
+++ b/OneTimePassword.xcodeproj/project.pbxproj
@@ -732,6 +732,7 @@
 			baseConfigurationReference = C996EC2C1A74D5830076B105 /* Debug.xcconfig */;
 			buildSettings = {
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 4.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -743,6 +744,7 @@
 			buildSettings = {
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 4.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};

--- a/OneTimePassword.xcodeproj/project.pbxproj
+++ b/OneTimePassword.xcodeproj/project.pbxproj
@@ -521,7 +521,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = "Matt Rubin";
 				TargetAttributes = {
 					5B39F4931DBD06BA00CD2DAB = {
@@ -742,6 +742,7 @@
 			baseConfigurationReference = C996EC2E1A74D5830076B105 /* Release.xcconfig */;
 			buildSettings = {
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};

--- a/OneTimePassword.xcodeproj/xcshareddata/xcschemes/OneTimePassword (iOS).xcscheme
+++ b/OneTimePassword.xcodeproj/xcshareddata/xcschemes/OneTimePassword (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -67,7 +66,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/OneTimePassword.xcodeproj/xcshareddata/xcschemes/OneTimePassword (watchOS).xcscheme
+++ b/OneTimePassword.xcodeproj/xcshareddata/xcschemes/OneTimePassword (watchOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -47,7 +46,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/OneTimePassword.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/OneTimePassword.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -30,7 +30,13 @@ func HMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
     let (hashFunction, hashLength) = algorithm.hashInfo
 
     let macOut = UnsafeMutablePointer<UInt8>.allocate(capacity: hashLength)
-    defer { macOut.deallocate(capacity: hashLength) }
+    defer {
+        #if swift(>=4.1)
+        macOut.deallocate()
+        #else
+        macOut.deallocate(capacity: hashLength)
+        #endif
+    }
 
     key.withUnsafeBytes { keyBytes in
         data.withUnsafeBytes { dataBytes in

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1</string>
+	<string>3.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3.1</string>
+	<string>3.1.1</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Tests/TokenSerializationTests.swift
+++ b/Tests/TokenSerializationTests.swift
@@ -98,9 +98,6 @@ class TokenSerializationTests: XCTestCase {
                                 let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
                                 let items = urlComponents?.queryItems
                                 let expectedItemCount = 4
-                                // SwiftLint gives a false positive here because of a Swift/SourceKit bug.
-                                // See https://github.com/realm/SwiftLint/issues/1785
-                                // swiftlint:disable vertical_parameter_alignment_on_call
                                 XCTAssertEqual(items?.count, expectedItemCount,
                                                "There shouldn't be any unexpected query arguments: \(url)")
                                 // swiftlint:enable vertical_parameter_alignment_on_call


### PR DESCRIPTION
Before merging:
- [x] Update the Info.plist
   - [x] Bump the short version number
   - [x] Bump the full build number
- [x] Update the pod spec
   - [x] Bump the version number
   - [x] Ensure the dependency versions match the Cartfile
   - [x] Make sure the deployment targets match the Xcode project
   - [x] Make sure `swift_version` specification and the `.swift-version` file are both correct
- [x] Test all builds methods
   - [x] Ensure all Xcode schemes build and tests pass
   - [x] `carthage build --no-skip-current`
   - [x] `pod spec lint` (against a release candidate tag)
- [x] Make sure the changelog is up to date
   - [x] Entries
   - [x] Version number
   - [x] Diff links
   - [x] Release date
- [x] Update the README (as necessary)
   - [x] Update the platform compatibility badges
   - [x] Update the installation instruction version numbers
   - [x] Update the usage note about version compatibility
   - [x] Update the usage example code

After merging:
- [x] Tag the release commit
- [x] Publish the GitHub release
- [x] Push the updated podspec (`pod trunk push`)
