### PR TITLE
Synthesize Equatable conformance when compiling with Swift 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ language: objective-c
 xcode_workspace: OneTimePassword.xcworkspace
 xcode_scheme: OneTimePassword (iOS)
 
-osx_image:
-  - xcode9
-  - xcode9.3
+osx_image: xcode9.3
 
 env:
   - RUNTIME="iOS 8.1"  DEVICE="iPad 2"
@@ -21,6 +19,8 @@ env:
 # Include builds for watchOS
 matrix:
   include:
+    - osx_image: xcode9
+      env: RUNTIME="iOS 11.0" DEVICE="iPhone X"
     - xcode_scheme: OneTimePassword (watchOS)
       env: BUILD_ONLY="YES" RUNTIME="watchOS 4.0" DEVICE="Apple Watch Series 3 - 38mm"
     - xcode_scheme: OneTimePassword (watchOS)

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env: RUNTIME="iOS 8.4"  DEVICE="iPhone 4s"
     # Include several build-only jobs for watchOS
     - xcode_scheme: OneTimePassword (watchOS)
-      env: BUILD_ONLY="YES" RUNTIME="watchOS 4.0" DEVICE="Apple Watch Series 3 - 38mm"
+      env: BUILD_ONLY="YES" RUNTIME="watchOS 4.3" DEVICE="Apple Watch Series 3 - 38mm"
     - xcode_scheme: OneTimePassword (watchOS)
       env: BUILD_ONLY="YES" RUNTIME="watchOS 3.2" DEVICE="Apple Watch Series 2 - 42mm"
     - xcode_scheme: OneTimePassword (watchOS)

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
   - if [[ $BUILD_ONLY == YES ]]; then ACTIONS="build"; else ACTIONS="build-for-testing test-without-building"; fi
   - echo "xcodebuild -workspace \"$TRAVIS_XCODE_WORKSPACE\" -scheme \"$TRAVIS_XCODE_SCHEME\" -destination \"id=$DESTINATION_ID\" $ACTIONS"
 
-script: set -o pipefail && travis_retry xcodebuild -workspace "$TRAVIS_XCODE_WORKSPACE" -scheme "$TRAVIS_XCODE_SCHEME" -destination "id=$DESTINATION_ID" $ACTIONS | xcpretty -c
+script: set -o pipefail && xcodebuild -workspace "$TRAVIS_XCODE_WORKSPACE" -scheme "$TRAVIS_XCODE_SCHEME" -destination "id=$DESTINATION_ID" $ACTIONS | xcpretty -c
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
   - if [[ $BUILD_ONLY == YES ]]; then ACTIONS="build"; else ACTIONS="build-for-testing test-without-building"; fi
   - echo "xcodebuild -workspace \"$TRAVIS_XCODE_WORKSPACE\" -scheme \"$TRAVIS_XCODE_SCHEME\" -destination \"id=$DESTINATION_ID\" $ACTIONS"
 
-script: set -o pipefail && xcodebuild -workspace "$TRAVIS_XCODE_WORKSPACE" -scheme "$TRAVIS_XCODE_SCHEME" -destination "id=$DESTINATION_ID" $ACTIONS | xcpretty -c
+script: set -o pipefail && travis_retry xcodebuild -workspace "$TRAVIS_XCODE_WORKSPACE" -scheme "$TRAVIS_XCODE_SCHEME" -destination "id=$DESTINATION_ID" $ACTIONS | xcpretty -c
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,8 @@ xcode_scheme: OneTimePassword (iOS)
 osx_image: xcode9.3
 
 env:
-  - RUNTIME="iOS 9.0"  DEVICE="iPhone 5s"
   - RUNTIME="iOS 9.3"  DEVICE="iPhone 6s"
-  - RUNTIME="iOS 10.0" DEVICE="iPhone SE"
   - RUNTIME="iOS 10.3" DEVICE="iPhone 7 Plus"
-  - RUNTIME="iOS 11.0" DEVICE="iPhone 8"
   - RUNTIME="iOS 11.3" DEVICE="iPhone X"
 
 # Include builds for watchOS
@@ -20,7 +17,7 @@ matrix:
   include:
     # Include an Xcode 9.0 build to test Swift 4.0 support
     - osx_image: xcode9
-      env: RUNTIME="iOS 11.0" DEVICE="iPhone X"
+      env: RUNTIME="iOS 11.0" DEVICE="iPhone 8"
     # Include an Xcode 9.2 build to test on iOS 8.x, because Xcode 9.3's iOS 8 simulator fails to launch
     - osx_image: xcode9.2
       env: RUNTIME="iOS 8.4"  DEVICE="iPhone 4s"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ env:
   - RUNTIME="iOS 9.3"  DEVICE="iPhone 6s"
   - RUNTIME="iOS 10.0" DEVICE="iPhone SE"
   - RUNTIME="iOS 10.3" DEVICE="iPhone 7 Plus"
-  - RUNTIME="iOS 11.0" DEVICE="iPhone X"
+  - RUNTIME="iOS 11.0" DEVICE="iPhone 8"
+  - RUNTIME="iOS 11.3" DEVICE="iPhone X"
 
 # Include builds for watchOS
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ language: objective-c
 xcode_workspace: OneTimePassword.xcworkspace
 xcode_scheme: OneTimePassword (iOS)
 
-osx_image: xcode9
+osx_image:
+  - xcode9
+  - xcode9.3
 
 env:
   - RUNTIME="iOS 8.1"  DEVICE="iPad 2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ xcode_scheme: OneTimePassword (iOS)
 osx_image: xcode9.3
 
 env:
-  - RUNTIME="iOS 8.1"  DEVICE="iPad 2"
-  - RUNTIME="iOS 8.4"  DEVICE="iPhone 4s"
   - RUNTIME="iOS 9.0"  DEVICE="iPhone 5s"
   - RUNTIME="iOS 9.3"  DEVICE="iPhone 6s"
   - RUNTIME="iOS 10.0" DEVICE="iPhone SE"
@@ -20,8 +18,13 @@ env:
 # Include builds for watchOS
 matrix:
   include:
+    # Include an Xcode 9.0 build to test Swift 4.0 support
     - osx_image: xcode9
       env: RUNTIME="iOS 11.0" DEVICE="iPhone X"
+    # Include an Xcode 9.2 build to test on iOS 8.x, because Xcode 9.3's iOS 8 simulator fails to launch
+    - osx_image: xcode9.2
+      env: RUNTIME="iOS 8.4"  DEVICE="iPhone 4s"
+    # Include several build-only jobs for watchOS
     - xcode_scheme: OneTimePassword (watchOS)
       env: BUILD_ONLY="YES" RUNTIME="watchOS 4.0" DEVICE="Apple Watch Series 3 - 38mm"
     - xcode_scheme: OneTimePassword (watchOS)

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -192,6 +192,8 @@ public struct Generator: Equatable {
     }
 }
 
+#if swift(>=4.1)
+#else
 /// Compares two `Generator`s for equality.
 public func == (lhs: Generator, rhs: Generator) -> Bool {
     return (lhs.factor == rhs.factor)
@@ -211,6 +213,7 @@ public func == (lhs: Generator.Factor, rhs: Generator.Factor) -> Bool {
         return false
     }
 }
+#endif
 
 // MARK: - Private
 

--- a/Sources/PersistentToken.swift
+++ b/Sources/PersistentToken.swift
@@ -48,8 +48,11 @@ public struct PersistentToken: Equatable, Hashable {
     }
 }
 
+#if swift(>=4.1)
+#else
 /// Compares two `PersistentToken`s for equality.
 public func == (lhs: PersistentToken, rhs: PersistentToken) -> Bool {
     return (lhs.identifier == rhs.identifier)
         && (lhs.token == rhs.token)
 }
+#endif

--- a/Sources/Token.swift
+++ b/Sources/Token.swift
@@ -70,9 +70,12 @@ public struct Token: Equatable {
     }
 }
 
+#if swift(>=4.1)
+#else
 /// Compares two `Token`s for equality.
 public func == (lhs: Token, rhs: Token) -> Bool {
     return (lhs.name == rhs.name)
         && (lhs.issuer == rhs.issuer)
         && (lhs.generator == rhs.generator)
 }
+#endif


### PR DESCRIPTION
Use conditional compilation blocks to manually implement equality operators for Swift 4.0 and below, but use compiler-synthesized implementations for Swift 4.1 and above. Configure the CI to build with Xcode 9.3 (Swift 4.1) by default, but also add an extra CI build to explicitly test building with Xcode 9.0 (Swift 4.0).