### PR TITLE
Ignore un-deserializable tokens in allPersistentTokens()

### DIFF
--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -47,7 +47,8 @@ public final class Keychain {
     ///
     /// - throws: A `Keychain.Error` if an error occurred.
     public func allPersistentTokens() throws -> Set<PersistentToken> {
-        return Set(try allKeychainItems().map(PersistentToken.init(keychainDictionary:)))
+        let allItems = try allKeychainItems()
+        return Set(allItems.flatMap({ try? PersistentToken.init(keychainDictionary:$0) }))
     }
 
     // MARK: Write

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -48,6 +48,10 @@ public final class Keychain {
     /// - throws: A `Keychain.Error` if an error occurred.
     public func allPersistentTokens() throws -> Set<PersistentToken> {
         let allItems = try allKeychainItems()
+        // This code intentionally ignores items which fail deserialization, instead opting to return as many readable
+        // tokens as possible.
+        // TODO: Restore deserialization error handling, in a way that provides info on the failure reason and allows
+        //       the caller to choose whether to fail completely or recover some data.
         return Set(allItems.flatMap({ try? PersistentToken.init(keychainDictionary:$0) }))
     }
 

--- a/Tests/KeychainTests.swift
+++ b/Tests/KeychainTests.swift
@@ -231,7 +231,8 @@ class KeychainTests: XCTestCase {
         let persistentRef = try addKeychainItem(withAttributes: keychainAttributes)
 
         XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef))
-        XCTAssertThrowsError(try keychain.allPersistentTokens())
+        // TODO: Restore deserialization error handling in allPersistentTokens()
+//        XCTAssertThrowsError(try keychain.allPersistentTokens())
 
         XCTAssertNoThrow(try deleteKeychainItem(forPersistentRef: persistentRef),
                          "Failed to delete the test token from the keychain. This may cause future test runs to fail.")
@@ -247,7 +248,8 @@ class KeychainTests: XCTestCase {
         let persistentRef = try addKeychainItem(withAttributes: keychainAttributes)
 
         XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef))
-        XCTAssertThrowsError(try keychain.allPersistentTokens())
+        // TODO: Restore deserialization error handling in allPersistentTokens()
+//        XCTAssertThrowsError(try keychain.allPersistentTokens())
 
         XCTAssertNoThrow(try deleteKeychainItem(forPersistentRef: persistentRef),
                          "Failed to delete the test token from the keychain. This may cause future test runs to fail.")
@@ -264,7 +266,8 @@ class KeychainTests: XCTestCase {
         let persistentRef = try addKeychainItem(withAttributes: keychainAttributes)
 
         XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef))
-        XCTAssertThrowsError(try keychain.allPersistentTokens())
+        // TODO: Restore deserialization error handling in allPersistentTokens()
+//        XCTAssertThrowsError(try keychain.allPersistentTokens())
 
         XCTAssertNoThrow(try deleteKeychainItem(forPersistentRef: persistentRef),
                          "Failed to delete the test token from the keychain. This may cause future test runs to fail.")
@@ -281,7 +284,8 @@ class KeychainTests: XCTestCase {
         let persistentRef = try addKeychainItem(withAttributes: keychainAttributes)
 
         XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef))
-        XCTAssertThrowsError(try keychain.allPersistentTokens())
+        // TODO: Restore deserialization error handling in allPersistentTokens()
+//        XCTAssertThrowsError(try keychain.allPersistentTokens())
 
         XCTAssertNoThrow(try deleteKeychainItem(forPersistentRef: persistentRef),
                          "Failed to delete the test token from the keychain. This may cause future test runs to fail.")


### PR DESCRIPTION
A [recent change](https://github.com/mattrubin/OneTimePassword/pull/161) to the behavior of `allPersistentTokens()` caused any individual persistent token which failed deserialization to cause the entire fetch to fail. Previously, individual tokens failing deserialization would be ignored, and the method would return as many readable tokens as possible.

That change has been the cause of a [crash on launch](https://github.com/mattrubin/Authenticator/issues/276) for many users of Authenticator. This PR reverts the behavior change until the cause of the underlying deserialization failures can be understood, and a recovery path provided.