### PR TITLE
Release OneTimePassword 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!--## [In development][develop]-->
 
+## [3.1.3][] (2018-04-29)
+- Ignore un-deserializable tokens in `allPersistentTokens()`. ([#179](https://github.com/mattrubin/OneTimePassword/pull/179))
+
+
 ## [3.1.2][] (2018-04-23)
 - Synthesize Equatable conformance when compiling with Swift 4.1. ([#173](https://github.com/mattrubin/OneTimePassword/pull/173))
 - Fix a warning about deprecation of cross-module struct initializers by simplifying test cases for impossible-to-create invalid Generators. ([#174](https://github.com/mattrubin/OneTimePassword/pull/174))
@@ -155,8 +159,9 @@ Changes between prerelease versions of OneTimePassword version 2 can be found be
 
 ## [1.0.0][] (2014-07-17)
 
-[develop]: https://github.com/mattrubin/OneTimePassword/compare/3.1.2...develop
+[develop]: https://github.com/mattrubin/OneTimePassword/compare/3.1.3...develop
 
+[3.1.3]: https://github.com/mattrubin/OneTimePassword/compare/3.1.2...3.1.3
 [3.1.2]: https://github.com/mattrubin/OneTimePassword/compare/3.1.1...3.1.2
 [3.1.1]: https://github.com/mattrubin/OneTimePassword/compare/3.1...3.1.1
 [3.1]: https://github.com/mattrubin/OneTimePassword/compare/3.0.1...3.1

--- a/OneTimePassword.podspec
+++ b/OneTimePassword.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "OneTimePassword"
-  s.version      = "3.1.2"
+  s.version      = "3.1.3"
   s.summary      = "A small library for generating TOTP and HOTP one-time passwords."
   s.homepage     = "https://github.com/mattrubin/OneTimePassword"
   s.license      = "MIT"

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.2</string>
+	<string>3.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3.1.2</string>
+	<string>3.1.3</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -47,7 +47,8 @@ public final class Keychain {
     ///
     /// - throws: A `Keychain.Error` if an error occurred.
     public func allPersistentTokens() throws -> Set<PersistentToken> {
-        return Set(try allKeychainItems().map(PersistentToken.init(keychainDictionary:)))
+        let allItems = try allKeychainItems()
+        return Set(allItems.flatMap({ try? PersistentToken.init(keychainDictionary:$0) }))
     }
 
     // MARK: Write

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -48,6 +48,10 @@ public final class Keychain {
     /// - throws: A `Keychain.Error` if an error occurred.
     public func allPersistentTokens() throws -> Set<PersistentToken> {
         let allItems = try allKeychainItems()
+        // This code intentionally ignores items which fail deserialization, instead opting to return as many readable
+        // tokens as possible.
+        // TODO: Restore deserialization error handling, in a way that provides info on the failure reason and allows
+        //       the caller to choose whether to fail completely or recover some data.
         return Set(allItems.flatMap({ try? PersistentToken.init(keychainDictionary:$0) }))
     }
 

--- a/Tests/KeychainTests.swift
+++ b/Tests/KeychainTests.swift
@@ -231,7 +231,8 @@ class KeychainTests: XCTestCase {
         let persistentRef = try addKeychainItem(withAttributes: keychainAttributes)
 
         XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef))
-        XCTAssertThrowsError(try keychain.allPersistentTokens())
+        // TODO: Restore deserialization error handling in allPersistentTokens()
+//        XCTAssertThrowsError(try keychain.allPersistentTokens())
 
         XCTAssertNoThrow(try deleteKeychainItem(forPersistentRef: persistentRef),
                          "Failed to delete the test token from the keychain. This may cause future test runs to fail.")
@@ -247,7 +248,8 @@ class KeychainTests: XCTestCase {
         let persistentRef = try addKeychainItem(withAttributes: keychainAttributes)
 
         XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef))
-        XCTAssertThrowsError(try keychain.allPersistentTokens())
+        // TODO: Restore deserialization error handling in allPersistentTokens()
+//        XCTAssertThrowsError(try keychain.allPersistentTokens())
 
         XCTAssertNoThrow(try deleteKeychainItem(forPersistentRef: persistentRef),
                          "Failed to delete the test token from the keychain. This may cause future test runs to fail.")
@@ -264,7 +266,8 @@ class KeychainTests: XCTestCase {
         let persistentRef = try addKeychainItem(withAttributes: keychainAttributes)
 
         XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef))
-        XCTAssertThrowsError(try keychain.allPersistentTokens())
+        // TODO: Restore deserialization error handling in allPersistentTokens()
+//        XCTAssertThrowsError(try keychain.allPersistentTokens())
 
         XCTAssertNoThrow(try deleteKeychainItem(forPersistentRef: persistentRef),
                          "Failed to delete the test token from the keychain. This may cause future test runs to fail.")
@@ -281,7 +284,8 @@ class KeychainTests: XCTestCase {
         let persistentRef = try addKeychainItem(withAttributes: keychainAttributes)
 
         XCTAssertThrowsError(try keychain.persistentToken(withIdentifier: persistentRef))
-        XCTAssertThrowsError(try keychain.allPersistentTokens())
+        // TODO: Restore deserialization error handling in allPersistentTokens()
+//        XCTAssertThrowsError(try keychain.allPersistentTokens())
 
         XCTAssertNoThrow(try deleteKeychainItem(forPersistentRef: persistentRef),
                          "Failed to delete the test token from the keychain. This may cause future test runs to fail.")


### PR DESCRIPTION
Before merging:
- [x] Update the Info.plist
   - [x] Bump the short version number
   - [x] Bump the full build number
- [x] Update the pod spec
   - [x] Bump the version number
   - [x] Ensure the dependency versions match the Cartfile
   - [x] Make sure the deployment targets match the Xcode project
   - [x] Make sure `swift_version` specification and the `.swift-version` file are both correct
- [x] Test all builds methods
   - [x] Ensure all Xcode schemes build and tests pass
   - [x] `carthage build --no-skip-current`
   - [x] `pod spec lint` (against a release candidate tag)
- [x] Make sure the changelog is up to date
   - [x] Entries
   - [x] Version number
   - [x] Diff links
   - [x] Release date
- [x] Update the README (as necessary)
   - [x] Update the platform compatibility badges
   - [x] Update the installation instruction version numbers
   - [x] Update the usage note about version compatibility
   - [x] Update the usage example code

After merging:
- [x] Tag the release commit
- [x] Publish the GitHub release
- [x] Push the updated podspec (`pod trunk push`)
