### PR TITLE
Fix compilation with Xcode 10 beta

### DIFF
--- a/CommonCrypto/appletvos/module.modulemap
+++ b/CommonCrypto/appletvos/module.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module CommonCryptoShim [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/appletvsimulator/module.modulemap
+++ b/CommonCrypto/appletvsimulator/module.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module CommonCryptoShim [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/iphoneos/module.modulemap
+++ b/CommonCrypto/iphoneos/module.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module CommonCryptoShim [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/iphonesimulator/module.modulemap
+++ b/CommonCrypto/iphonesimulator/module.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module CommonCryptoShim [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/macosx/module.modulemap
+++ b/CommonCrypto/macosx/module.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module CommonCryptoShim [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/watchos/module.modulemap
+++ b/CommonCrypto/watchos/module.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module CommonCryptoShim [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/watchsimulator/module.modulemap
+++ b/CommonCrypto/watchsimulator/module.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module CommonCryptoShim [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -24,7 +24,11 @@
 //
 
 import Foundation
+#if canImport(CommonCrypto)
 import CommonCrypto
+#else
+import CommonCryptoShim
+#endif
 
 func HMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
     let (hashFunction, hashLength) = algorithm.hashInfo

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -24,10 +24,14 @@
 //
 
 import Foundation
-#if canImport(CommonCrypto)
-import CommonCrypto
+#if swift(>=4.1)
+    #if canImport(CommonCrypto)
+        import CommonCrypto
+    #else
+        import CommonCryptoShim
+    #endif
 #else
-import CommonCryptoShim
+    import CommonCryptoShim
 #endif
 
 func HMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {


### PR DESCRIPTION
The iOS 12 SDK now provides a module map for CommonCrypto. Using `#if canImport(CommonCrypto)` and the module map shims allows for correct compilation with both the old and new SDKs. Since the `canImport` check was added in Swift 4.1, an additional `#if swift(>=4.1)` is needed to maintain support from Swift 4.0.
