### PR TITLE
Update SwiftLint configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -50,10 +50,12 @@ opt_in_rules:
   - vertical_parameter_alignment_on_call
   - yoda_condition
 disabled_rules:
-  - colon
   - comma
   - cyclomatic_complexity
   - identifier_name
+
+colon:
+  flexible_right_spacing: true
 
 trailing_comma:
   mandatory_comma: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,14 +9,17 @@ opt_in_rules:
   - closure_spacing
   - conditional_returns_on_newline
   - contains_over_first_not_nil
+  - convenience_type
   - discouraged_object_literal
   - discouraged_optional_boolean
   - discouraged_optional_collection
   - empty_count
   - empty_string
+  - empty_xctest_method
   - explicit_enum_raw_value
   - explicit_init
   - extension_access_modifier
+  - fallthrough
   - fatal_error_message
   - file_header
   - first_where
@@ -26,18 +29,22 @@ opt_in_rules:
   - let_var_whitespace
   - literal_expression_end_indentation
   - lower_acl_than_parent
+  - modifier_order
+  - multiline_function_chains
   - multiline_parameters
   - nimble_operator
   - operator_usage_whitespace
   - overridden_super_call
   - override_in_extension
   - pattern_matching_keywords
+  - private_action
   - private_outlet
   - prohibited_super_call
   - redundant_nil_coalescing
   - single_test_class
   - sorted_first_last
   - switch_case_on_newline
+  - unavailable_function
   - unneeded_parentheses_in_closure_argument
   - untyped_error_in_catch
   - vertical_parameter_alignment_on_call

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -50,7 +50,6 @@ opt_in_rules:
   - vertical_parameter_alignment_on_call
   - yoda_condition
 disabled_rules:
-  - comma
   - cyclomatic_complexity
   - identifier_name
 

--- a/OneTimePasswordLegacyTests/OTPToken.swift
+++ b/OneTimePasswordLegacyTests/OTPToken.swift
@@ -30,7 +30,7 @@ import OneTimePassword
 /// information about its properties and methods, consult the underlying `OneTimePassword`
 /// documentation.
 public final class OTPToken: NSObject {
-    required public override init() {}
+    override public required init() {}
 
     @objc public var name: String = OTPToken.defaultName
     @objc public var issuer: String = OTPToken.defaultIssuer

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -52,7 +52,7 @@ public final class Keychain {
         // tokens as possible.
         // TODO: Restore deserialization error handling, in a way that provides info on the failure reason and allows
         //       the caller to choose whether to fail completely or recover some data.
-        return Set(allItems.flatMap({ try? PersistentToken(keychainDictionary:$0) }))
+        return Set(allItems.flatMap({ try? PersistentToken(keychainDictionary: $0) }))
     }
 
     // MARK: Write
@@ -180,7 +180,7 @@ private func addKeychainItem(withAttributes attributes: [String: AnyObject]) thr
 
 private func updateKeychainItem(forPersistentRef persistentRef: Data,
                                 withAttributes attributesToUpdate: [String: AnyObject]) throws {
-    let queryDict: [String : AnyObject] = [
+    let queryDict: [String: AnyObject] = [
         kSecClass as String:               kSecClassGenericPassword,
         kSecValuePersistentRef as String:  persistentRef as NSData,
     ]
@@ -193,7 +193,7 @@ private func updateKeychainItem(forPersistentRef persistentRef: Data,
 }
 
 private func deleteKeychainItem(forPersistentRef persistentRef: Data) throws {
-    let queryDict: [String : AnyObject] = [
+    let queryDict: [String: AnyObject] = [
         kSecClass as String:               kSecClassGenericPassword,
         kSecValuePersistentRef as String:  persistentRef as NSData,
     ]
@@ -206,7 +206,7 @@ private func deleteKeychainItem(forPersistentRef persistentRef: Data) throws {
 }
 
 private func keychainItem(forPersistentRef persistentRef: Data) throws -> NSDictionary? {
-    let queryDict: [String : AnyObject] = [
+    let queryDict: [String: AnyObject] = [
         kSecClass as String:                kSecClassGenericPassword,
         kSecValuePersistentRef as String:   persistentRef as NSData,
         kSecReturnPersistentRef as String:  kCFBooleanTrue,
@@ -233,7 +233,7 @@ private func keychainItem(forPersistentRef persistentRef: Data) throws -> NSDict
 }
 
 private func allKeychainItems() throws -> [NSDictionary] {
-    let queryDict: [String : AnyObject] = [
+    let queryDict: [String: AnyObject] = [
         kSecClass as String:                kSecClassGenericPassword,
         kSecMatchLimit as String:           kSecMatchLimitAll,
         kSecReturnPersistentRef as String:  kCFBooleanTrue,

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -52,7 +52,7 @@ public final class Keychain {
         // tokens as possible.
         // TODO: Restore deserialization error handling, in a way that provides info on the failure reason and allows
         //       the caller to choose whether to fail completely or recover some data.
-        return Set(allItems.flatMap({ try? PersistentToken.init(keychainDictionary:$0) }))
+        return Set(allItems.flatMap({ try? PersistentToken(keychainDictionary:$0) }))
     }
 
     // MARK: Write

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -73,11 +73,13 @@ class GeneratorTests: XCTestCase {
 
     func testCounter() {
         let factors: [(TimeInterval, TimeInterval, UInt64)] = [
+            // swiftlint:disable comma
             (100,         30, 3),
             (10000,       30, 333),
             (1000000,     30, 33333),
             (100000000,   60, 1666666),
             (10000000000, 90, 111111111),
+            // swiftlint:enable comma
         ]
 
         for (timeSinceEpoch, period, count) in factors {

--- a/Tests/KeychainTests.swift
+++ b/Tests/KeychainTests.swift
@@ -319,7 +319,7 @@ private func addKeychainItem(withAttributes attributes: [String: AnyObject]) thr
 }
 
 public func deleteKeychainItem(forPersistentRef persistentRef: Data) throws {
-    let queryDict: [String : AnyObject] = [
+    let queryDict: [String: AnyObject] = [
         kSecClass as String:               kSecClassGenericPassword,
         kSecValuePersistentRef as String:  persistentRef as NSData,
     ]


### PR DESCRIPTION
- Remove an unnecessary explicit call to `.init()`
- Enforce consistent modifier order
- Clean up whitespace around colons