### PR TITLE
Add CI builds for Carthage and CocoaPods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ matrix:
     - xcode_scheme: OneTimePassword (watchOS)
       env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
     # Include CocoaPods builds
-    - osx_image: xcode9
-      env: null
-      before_install: gem update cocoapods
-      before_script: null
-      script: pod lib lint --allow-warnings
+    # - osx_image: xcode9
+    #   env: null
+    #   before_install: gem update cocoapods
+    #   before_script: null
+    #   script: pod lib lint --allow-warnings
     - osx_image: xcode10
       env: null
       before_script: null

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,6 @@ matrix:
       before_script:
       script: pod lib lint --allow-warnings
 
-
-# Check out nested dependencies
-install: git submodule update --init --recursive
-
 before_script:
   - DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
   - RUNTIME_ID=com.apple.CoreSimulator.SimRuntime.$(echo $RUNTIME | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 3.2" DEVICE="Apple Watch Series 2 - 42mm"
     - xcode_scheme: OneTimePassword (watchOS)
       env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
+    # Include CocoaPods builds
+    - script: pod lib lint
+    - osx_image: xcode9
+      script: pod lib lint
 
 # Check out nested dependencies
 before_install: git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,13 @@ matrix:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
     # Include CocoaPods builds
     - osx_image: xcode9
-      env: []
+      env: null
       before_install: gem update cocoapods
-      before_script: []
+      before_script: null
       script: pod lib lint --allow-warnings
     - osx_image: xcode10
-      env: []
-      before_script: []
+      env: null
+      before_script: null
       script: pod lib lint --allow-warnings
 
 # Check out nested dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,12 @@ matrix:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 3.2" DEVICE="Apple Watch Series 2 - 42mm"
     - xcode_scheme: OneTimePassword (watchOS)
       env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
-    # Include a Carthage build
+    # Include Carthage builds
     - env: null
+      before_script: null
+      script: carthage build --no-skip-current
+    - osx_image: xcode9
+      env: null
       before_script: null
       script: carthage build --no-skip-current
     # Include CocoaPods builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,11 @@ matrix:
       env: []
       before_install: gem update cocoapods
       before_script: []
-      script: pod lib lint
+      script: pod lib lint --allow-warnings
     - osx_image: xcode10
       env: []
       before_script: []
-      script: pod lib lint
+      script: pod lib lint --allow-warnings
 
 # Check out nested dependencies
 install: git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,13 @@ matrix:
     - xcode_scheme: OneTimePassword (watchOS)
       env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
     # Include CocoaPods builds
-    - script: pod lib lint
     - osx_image: xcode9
+      env: []
+      before_script: []
+      script: pod lib lint
+    - osx_image: xcode10
+      env: []
+      before_script: []
       script: pod lib lint
 
 # Check out nested dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       env:
       before_install: gem update cocoapods
       before_script:
-      script: pod lib lint --allow-warnings
+      script: pod lib lint --allow-warnings --verbose
     - osx_image: xcode10
       env: null
       before_script: null
@@ -49,7 +49,7 @@ matrix:
       env:
       before_install: gem update cocoapods
       before_script:
-      script: pod lib lint --allow-warnings
+      script: pod lib lint --allow-warnings --verbose
 
 before_script:
   - DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
     # Include CocoaPods builds
     - osx_image: xcode9
       env: []
+      before_install: gem update cocoapods
       before_script: []
       script: pod lib lint
     - osx_image: xcode10
@@ -45,7 +46,7 @@ matrix:
       script: pod lib lint
 
 # Check out nested dependencies
-before_install: git submodule update --init --recursive
+install: git submodule update --init --recursive
 
 before_script:
   - DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,22 @@ matrix:
     - xcode_scheme: OneTimePassword (watchOS)
       env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
     # Include CocoaPods builds
-    # - osx_image: xcode9
-    #   env: null
-    #   before_install: gem update cocoapods
-    #   before_script: null
-    #   script: pod lib lint --allow-warnings
+    - osx_image: xcode9
+      env:
+      before_install: gem update cocoapods
+      before_script:
+      script: pod lib lint --allow-warnings
     - osx_image: xcode10
       env: null
       before_script: null
       script: pod lib lint --allow-warnings
+  allow_failures:
+    - osx_image: xcode9
+      env:
+      before_install: gem update cocoapods
+      before_script:
+      script: pod lib lint --allow-warnings
+
 
 # Check out nested dependencies
 install: git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 3.2" DEVICE="Apple Watch Series 2 - 42mm"
     - xcode_scheme: OneTimePassword (watchOS)
       env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
+    # Include a Carthage build
+    - env: null
+      before_script: null
+      script: carthage build --no-skip-current
     # Include CocoaPods builds
     - osx_image: xcode9
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,24 +35,24 @@ matrix:
     - xcode_scheme: OneTimePassword (watchOS)
       env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
     # Include Carthage builds
-    - env: null
-      before_script: null
+    - env:
+      before_script:
       script: carthage build --no-skip-current
     - osx_image: xcode9
-      env: null
-      before_script: null
+      env:
+      before_script:
       script: carthage build --no-skip-current
     # Include CocoaPods builds
+    - env:
+      before_script:
+      script: pod lib lint --allow-warnings
     - osx_image: xcode9
       env:
       before_install: gem update cocoapods
       before_script:
       script: pod lib lint --allow-warnings --verbose
-    - osx_image: xcode10
-      env: null
-      before_script: null
-      script: pod lib lint --allow-warnings
   allow_failures:
+    # Allow the Xcode 9 `pod lib lint` to fail, as this test method currently has an issue using the custom CommonCrypto module maps.
     - osx_image: xcode9
       env:
       before_install: gem update cocoapods


### PR DESCRIPTION
Add CI jobs which try building the library with Carthage and CocoaPods, on both Xcode 9 and 10.

Currently, CocoaPods' `pod lib lint` command has a bug with the `preserve_paths` configuration used to provide custom CommonCrypto modulemaps on Xcode 9.x. Until that bug is fixed, the Xcode 9 CocoaPods CI job is allowed to fail.