### PR TITLE
Support for customization of keychain usage (ObjC branch)

### DIFF
--- a/OneTimePassword.xcodeproj/project.pbxproj
+++ b/OneTimePassword.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1B4A983B21C3D54D00F44004 /* OTPToken+Persistence.m in Sources */ = {isa = PBXBuildFile; fileRef = C93A24F7196AF8E900F86892 /* OTPToken+Persistence.m */; };
+		1B4A984421C3DE0B00F44004 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B4A984321C3DE0B00F44004 /* AppDelegate.m */; };
+		1B4A984721C3DE0B00F44004 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B4A984621C3DE0B00F44004 /* ViewController.m */; };
+		1B4A984A21C3DE0B00F44004 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1B4A984821C3DE0B00F44004 /* Main.storyboard */; };
+		1B4A984C21C3DE0D00F44004 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1B4A984B21C3DE0D00F44004 /* Assets.xcassets */; };
+		1B4A984F21C3DE0D00F44004 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1B4A984D21C3DE0D00F44004 /* LaunchScreen.storyboard */; };
+		1B4A985221C3DE0D00F44004 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B4A985121C3DE0D00F44004 /* main.m */; };
 		B6C6D5560BC6437A8E4F8580 /* libPods-OneTimePassword.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 560131D4F5D140EA8458D149 /* libPods-OneTimePassword.a */; };
 		C93A24FE196AF8E900F86892 /* OTPAlgorithm.h in Headers */ = {isa = PBXBuildFile; fileRef = C93A24F2196AF8E900F86892 /* OTPAlgorithm.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C93A24FF196AF8E900F86892 /* OTPAlgorithm.m in Sources */ = {isa = PBXBuildFile; fileRef = C93A24F3196AF8E900F86892 /* OTPAlgorithm.m */; };
@@ -31,6 +38,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1B4A985621C3DE3200F44004 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C97C822F1946E51D00FD9F4C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1B4A983F21C3DE0B00F44004;
+			remoteInfo = OneTimePasswordTestHost;
+		};
 		C97C82451946E51D00FD9F4C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C97C822F1946E51D00FD9F4C /* Project object */;
@@ -41,6 +55,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1B4A984021C3DE0B00F44004 /* OneTimePasswordTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OneTimePasswordTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1B4A984221C3DE0B00F44004 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		1B4A984321C3DE0B00F44004 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		1B4A984521C3DE0B00F44004 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		1B4A984621C3DE0B00F44004 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		1B4A984921C3DE0B00F44004 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		1B4A984B21C3DE0D00F44004 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		1B4A984E21C3DE0D00F44004 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		1B4A985021C3DE0D00F44004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1B4A985121C3DE0D00F44004 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		4A7643FD57ED1F34ED96D4DB /* Pods-OneTimePassword.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OneTimePassword.release.xcconfig"; path = "Pods/Target Support Files/Pods-OneTimePassword/Pods-OneTimePassword.release.xcconfig"; sourceTree = "<group>"; };
 		560131D4F5D140EA8458D149 /* libPods-OneTimePassword.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OneTimePassword.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B0E42750F64443678FAFD9B /* Pods-OneTimePassword.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OneTimePassword.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OneTimePassword/Pods-OneTimePassword.debug.xcconfig"; sourceTree = "<group>"; };
@@ -72,6 +96,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1B4A983D21C3DE0B00F44004 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C97C82341946E51D00FD9F4C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -91,6 +122,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1B4A984121C3DE0B00F44004 /* OneTimePasswordTestHost */ = {
+			isa = PBXGroup;
+			children = (
+				1B4A984221C3DE0B00F44004 /* AppDelegate.h */,
+				1B4A984321C3DE0B00F44004 /* AppDelegate.m */,
+				1B4A984521C3DE0B00F44004 /* ViewController.h */,
+				1B4A984621C3DE0B00F44004 /* ViewController.m */,
+				1B4A984821C3DE0B00F44004 /* Main.storyboard */,
+				1B4A984B21C3DE0D00F44004 /* Assets.xcassets */,
+				1B4A984D21C3DE0D00F44004 /* LaunchScreen.storyboard */,
+				1B4A985021C3DE0D00F44004 /* Info.plist */,
+				1B4A985121C3DE0D00F44004 /* main.m */,
+			);
+			path = OneTimePasswordTestHost;
+			sourceTree = "<group>";
+		};
 		746E7166AD60449882DD84C7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -104,6 +151,7 @@
 			children = (
 				C97C823A1946E51D00FD9F4C /* OneTimePassword */,
 				C97C82471946E51D00FD9F4C /* OneTimePasswordTests */,
+				1B4A984121C3DE0B00F44004 /* OneTimePasswordTestHost */,
 				746E7166AD60449882DD84C7 /* Frameworks */,
 				C97C82391946E51D00FD9F4C /* Products */,
 				D51C4BB102CF877149530BC7 /* Pods */,
@@ -117,6 +165,7 @@
 			children = (
 				C97C82381946E51D00FD9F4C /* OneTimePassword.framework */,
 				C97C82431946E51D00FD9F4C /* OneTimePasswordTests.xctest */,
+				1B4A984021C3DE0B00F44004 /* OneTimePasswordTestHost.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -203,6 +252,23 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		1B4A983F21C3DE0B00F44004 /* OneTimePasswordTestHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1B4A985321C3DE0D00F44004 /* Build configuration list for PBXNativeTarget "OneTimePasswordTestHost" */;
+			buildPhases = (
+				1B4A983C21C3DE0B00F44004 /* Sources */,
+				1B4A983D21C3DE0B00F44004 /* Frameworks */,
+				1B4A983E21C3DE0B00F44004 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OneTimePasswordTestHost;
+			productName = OneTimePasswordTestHost;
+			productReference = 1B4A984021C3DE0B00F44004 /* OneTimePasswordTestHost.app */;
+			productType = "com.apple.product-type.application";
+		};
 		C97C82371946E51D00FD9F4C /* OneTimePassword */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C97C824E1946E51D00FD9F4C /* Build configuration list for PBXNativeTarget "OneTimePassword" */;
@@ -235,6 +301,7 @@
 			);
 			dependencies = (
 				C97C82461946E51D00FD9F4C /* PBXTargetDependency */,
+				1B4A985721C3DE3200F44004 /* PBXTargetDependency */,
 			);
 			name = OneTimePasswordTests;
 			productName = OneTimePasswordTests;
@@ -251,12 +318,16 @@
 				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = "Matt Rubin";
 				TargetAttributes = {
+					1B4A983F21C3DE0B00F44004 = {
+						CreatedOnToolsVersion = 10.1;
+						ProvisioningStyle = Automatic;
+					};
 					C97C82371946E51D00FD9F4C = {
 						CreatedOnToolsVersion = 6.0;
 					};
 					C97C82421946E51D00FD9F4C = {
 						CreatedOnToolsVersion = 6.0;
-						TestTargetID = C97C82371946E51D00FD9F4C;
+						TestTargetID = 1B4A983F21C3DE0B00F44004;
 					};
 				};
 			};
@@ -266,6 +337,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = C97C822E1946E51D00FD9F4C;
 			productRefGroup = C97C82391946E51D00FD9F4C /* Products */;
@@ -274,11 +346,22 @@
 			targets = (
 				C97C82371946E51D00FD9F4C /* OneTimePassword */,
 				C97C82421946E51D00FD9F4C /* OneTimePasswordTests */,
+				1B4A983F21C3DE0B00F44004 /* OneTimePasswordTestHost */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1B4A983E21C3DE0B00F44004 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1B4A984F21C3DE0D00F44004 /* LaunchScreen.storyboard in Resources */,
+				1B4A984C21C3DE0D00F44004 /* Assets.xcassets in Resources */,
+				1B4A984A21C3DE0B00F44004 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C97C82361946E51D00FD9F4C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -329,6 +412,16 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1B4A983C21C3DE0B00F44004 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1B4A984721C3DE0B00F44004 /* ViewController.m in Sources */,
+				1B4A985221C3DE0D00F44004 /* main.m in Sources */,
+				1B4A984421C3DE0B00F44004 /* AppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C97C82331946E51D00FD9F4C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -350,6 +443,7 @@
 				C93A2516196AFE1100F86892 /* OTPTokenGenerationTests.m in Sources */,
 				C93BD5ED1C12A05400FFFB8F /* NSDictionary+QueryItems.m in Sources */,
 				C983AB6F197F913400975003 /* OTPBase32Tests.m in Sources */,
+				1B4A983B21C3D54D00F44004 /* OTPToken+Persistence.m in Sources */,
 				C93A2517196AFE1100F86892 /* OTPTokenPersistenceTests.m in Sources */,
 				C93A2518196AFE1100F86892 /* OTPTokenSerializationTests.m in Sources */,
 			);
@@ -358,6 +452,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		1B4A985721C3DE3200F44004 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1B4A983F21C3DE0B00F44004 /* OneTimePasswordTestHost */;
+			targetProxy = 1B4A985621C3DE3200F44004 /* PBXContainerItemProxy */;
+		};
 		C97C82461946E51D00FD9F4C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C97C82371946E51D00FD9F4C /* OneTimePassword */;
@@ -365,7 +464,95 @@
 		};
 /* End PBXTargetDependency section */
 
+/* Begin PBXVariantGroup section */
+		1B4A984821C3DE0B00F44004 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1B4A984921C3DE0B00F44004 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		1B4A984D21C3DE0D00F44004 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1B4A984E21C3DE0D00F44004 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		1B4A985421C3DE0D00F44004 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = OneTimePasswordTestHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = me.mattrubin.OneTimePasswordTestHost.OneTimePasswordTestHost;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1B4A985521C3DE0D00F44004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = OneTimePasswordTestHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = me.mattrubin.OneTimePasswordTestHost.OneTimePasswordTestHost;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		C97C824C1946E51D00FD9F4C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -510,6 +697,7 @@
 				METAL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.mattrubin.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OneTimePasswordTestHost.app/OneTimePasswordTestHost";
 			};
 			name = Debug;
 		};
@@ -525,12 +713,22 @@
 				METAL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.mattrubin.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OneTimePasswordTestHost.app/OneTimePasswordTestHost";
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1B4A985321C3DE0D00F44004 /* Build configuration list for PBXNativeTarget "OneTimePasswordTestHost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1B4A985421C3DE0D00F44004 /* Debug */,
+				1B4A985521C3DE0D00F44004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C97C82321946E51D00FD9F4C /* Build configuration list for PBXProject "OneTimePassword" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/OneTimePassword/OTPToken+Persistence.m
+++ b/OneTimePassword/OTPToken+Persistence.m
@@ -136,6 +136,7 @@
     NSDictionary *queryDict = @{(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
                                 (__bridge id)kSecValuePersistentRef: persistentRef,
                                 (__bridge id)kSecReturnPersistentRef: (id)kCFBooleanTrue,
+                                (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
                                 (__bridge id)kSecReturnAttributes: (id)kCFBooleanTrue,
                                 (__bridge id)kSecReturnData: (id)kCFBooleanTrue
                                 };
@@ -152,6 +153,7 @@
     NSDictionary *queryDict = @{(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
                                 (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitAll,
                                 (__bridge id)kSecReturnPersistentRef: (id)kCFBooleanTrue,
+                                (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
                                 (__bridge id)kSecReturnAttributes: (id)kCFBooleanTrue,
                                 (__bridge id)kSecReturnData: (id)kCFBooleanTrue
                                 };

--- a/OneTimePassword/OTPToken+Persistence.m
+++ b/OneTimePassword/OTPToken+Persistence.m
@@ -101,9 +101,10 @@
         attributes[(__bridge id)kSecValueData] = self.secret;
         attributes[(__bridge id)kSecAttrService] = [self.class keychainServiceName];
 
-        if ([self.class supportCloudKeychain])
-        {
+        // iCloud keychain access requires an access group
+        if ([self.class supportCloudKeychain] && [self.class keychainAccessGroup]) {
             attributes[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kCFBooleanTrue;
+            attributes[(__bridge id)kSecAttrAccessGroup] = [self.class keychainAccessGroup];
         }
         
         NSData *persistentRef = [OTPToken addKeychainItemWithAttributes:attributes];

--- a/OneTimePassword/OTPToken+Persistence.m
+++ b/OneTimePassword/OTPToken+Persistence.m
@@ -27,9 +27,6 @@
 @import ObjectiveC.runtime;
 
 
-static NSString *const kOTPService = @"me.mattrubin.authenticator.token";
-
-
 @interface OTPToken ()
 
 @property (nonatomic, strong) NSData *keychainItemRef;
@@ -102,8 +99,13 @@ static NSString *const kOTPService = @"me.mattrubin.authenticator.token";
                                              withAttributes:attributes];
     } else {
         attributes[(__bridge id)kSecValueData] = self.secret;
-        attributes[(__bridge id)kSecAttrService] = kOTPService;
+        attributes[(__bridge id)kSecAttrService] = [self.class keychainServiceName];
 
+        if ([self.class supportCloudKeychain])
+        {
+            attributes[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kCFBooleanTrue;
+        }
+        
         NSData *persistentRef = [OTPToken addKeychainItemWithAttributes:attributes];
 
         self.keychainItemRef = persistentRef;

--- a/OneTimePassword/OTPToken.h
+++ b/OneTimePassword/OTPToken.h
@@ -48,6 +48,10 @@
 @property (nonatomic) NSTimeInterval period;
 + (NSTimeInterval)defaultPeriod;
 
+// Create your own OTPToken subclass if you want to customize persistance of the tokens in the keychain
++ (NSString *)keychainServiceName;
++ (BOOL)supportCloudKeychain;
+
 // Validation
 - (BOOL)validate;
 

--- a/OneTimePassword/OTPToken.h
+++ b/OneTimePassword/OTPToken.h
@@ -50,6 +50,7 @@
 
 // Create your own OTPToken subclass if you want to customize persistance of the tokens in the keychain
 + (NSString *)keychainServiceName;
++ (NSString *)keychainAccessGroup;
 + (BOOL)supportCloudKeychain;
 
 // Validation

--- a/OneTimePassword/OTPToken.m
+++ b/OneTimePassword/OTPToken.m
@@ -26,6 +26,7 @@
 
 
 static NSString *const OTPTokenInternalTimerNotification = @"OTPTokenInternalTimerNotification";
+static NSString *const kOTPService = @"me.mattrubin.authenticator.token";
 
 
 @implementation OTPToken
@@ -91,6 +92,16 @@ static NSString *const OTPTokenInternalTimerNotification = @"OTPTokenInternalTim
 + (NSTimeInterval)defaultPeriod
 {
     return 30;
+}
+
++ (NSString *)keychainServiceName;
+{
+    return kOTPService;
+}
+
++ (BOOL)supportCloudKeychain
+{
+    return NO;
 }
 
 

--- a/OneTimePassword/OTPToken.m
+++ b/OneTimePassword/OTPToken.m
@@ -99,6 +99,11 @@ static NSString *const kOTPService = @"me.mattrubin.authenticator.token";
     return kOTPService;
 }
 
++ (NSString *)keychainAccessGroup
+{
+    return nil;
+}
+
 + (BOOL)supportCloudKeychain
 {
     return NO;

--- a/OneTimePasswordTestHost/AppDelegate.h
+++ b/OneTimePasswordTestHost/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  OneTimePasswordTestHost
+//
+//  Created by Ulrich Kreuzeder on 14.12.18.
+//  Copyright © 2018 Matt Rubin. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/OneTimePasswordTestHost/AppDelegate.h
+++ b/OneTimePasswordTestHost/AppDelegate.h
@@ -2,8 +2,25 @@
 //  AppDelegate.h
 //  OneTimePasswordTestHost
 //
-//  Created by Ulrich Kreuzeder on 14.12.18.
-//  Copyright © 2018 Matt Rubin. All rights reserved.
+//  Copyright (c) 2018 Matt Rubin and the OneTimePassword authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 #import <UIKit/UIKit.h>

--- a/OneTimePasswordTestHost/AppDelegate.m
+++ b/OneTimePasswordTestHost/AppDelegate.m
@@ -2,8 +2,25 @@
 //  AppDelegate.m
 //  OneTimePasswordTestHost
 //
-//  Created by Ulrich Kreuzeder on 14.12.18.
-//  Copyright © 2018 Matt Rubin. All rights reserved.
+//  Copyright (c) 2018 Matt Rubin and the OneTimePassword authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 #import "AppDelegate.h"

--- a/OneTimePasswordTestHost/AppDelegate.m
+++ b/OneTimePasswordTestHost/AppDelegate.m
@@ -1,0 +1,51 @@
+//
+//  AppDelegate.m
+//  OneTimePasswordTestHost
+//
+//  Created by Ulrich Kreuzeder on 14.12.18.
+//  Copyright © 2018 Matt Rubin. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+}
+
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+}
+
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+
+@end

--- a/OneTimePasswordTestHost/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/OneTimePasswordTestHost/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/OneTimePasswordTestHost/Assets.xcassets/Contents.json
+++ b/OneTimePasswordTestHost/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/OneTimePasswordTestHost/Base.lproj/LaunchScreen.storyboard
+++ b/OneTimePasswordTestHost/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/OneTimePasswordTestHost/Base.lproj/Main.storyboard
+++ b/OneTimePasswordTestHost/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/OneTimePasswordTestHost/Info.plist
+++ b/OneTimePasswordTestHost/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/OneTimePasswordTestHost/ViewController.h
+++ b/OneTimePasswordTestHost/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  OneTimePasswordTestHost
+//
+//  Created by Ulrich Kreuzeder on 14.12.18.
+//  Copyright © 2018 Matt Rubin. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/OneTimePasswordTestHost/ViewController.h
+++ b/OneTimePasswordTestHost/ViewController.h
@@ -2,8 +2,25 @@
 //  ViewController.h
 //  OneTimePasswordTestHost
 //
-//  Created by Ulrich Kreuzeder on 14.12.18.
-//  Copyright © 2018 Matt Rubin. All rights reserved.
+//  Copyright (c) 2018 Matt Rubin and the OneTimePassword authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 #import <UIKit/UIKit.h>

--- a/OneTimePasswordTestHost/ViewController.m
+++ b/OneTimePasswordTestHost/ViewController.m
@@ -2,8 +2,25 @@
 //  ViewController.m
 //  OneTimePasswordTestHost
 //
-//  Created by Ulrich Kreuzeder on 14.12.18.
-//  Copyright © 2018 Matt Rubin. All rights reserved.
+//  Copyright (c) 2018 Matt Rubin and the OneTimePassword authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 #import "ViewController.h"

--- a/OneTimePasswordTestHost/ViewController.m
+++ b/OneTimePasswordTestHost/ViewController.m
@@ -1,0 +1,23 @@
+//
+//  ViewController.m
+//  OneTimePasswordTestHost
+//
+//  Created by Ulrich Kreuzeder on 14.12.18.
+//  Copyright © 2018 Matt Rubin. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view, typically from a nib.
+}
+
+
+@end

--- a/OneTimePasswordTestHost/main.m
+++ b/OneTimePasswordTestHost/main.m
@@ -2,8 +2,25 @@
 //  main.m
 //  OneTimePasswordTestHost
 //
-//  Created by Ulrich Kreuzeder on 14.12.18.
-//  Copyright © 2018 Matt Rubin. All rights reserved.
+//  Copyright (c) 2018 Matt Rubin and the OneTimePassword authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 #import <UIKit/UIKit.h>

--- a/OneTimePasswordTestHost/main.m
+++ b/OneTimePasswordTestHost/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  OneTimePasswordTestHost
+//
+//  Created by Ulrich Kreuzeder on 14.12.18.
+//  Copyright © 2018 Matt Rubin. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}


### PR DESCRIPTION
This small set of changes allows for customization of how the tokens are stored in the keychain. Users can create a subclass of OTPToken and overwrite class methods to provide a custom keychain service name, define a keychain access group and also enable iCloud Keychain usage.

Defaults leave everything as before.

Additionally, a test host app has been added for the unit tests, to support keychain based tests with Xcode 10.