### PR TITLE
Background config update

### DIFF
--- a/OneTimePassword.podspec
+++ b/OneTimePassword.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "OneTimePassword"
-  s.version      = "3.1.5"
+  s.version      = "3.1.6"
   s.summary      = "A small library for generating TOTP and HOTP one-time passwords."
   s.homepage     = "https://github.com/mattrubin/OneTimePassword"
   s.license      = "MIT"

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -34,7 +34,7 @@ import Foundation
     import CommonCryptoShim
 #endif
 
-func HMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
+public func HMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
     let (hashFunction, hashLength) = algorithm.hashInfo
 
     let macOut = UnsafeMutablePointer<UInt8>.allocate(capacity: hashLength)

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -123,6 +123,9 @@ private extension Token {
             kSecAttrGeneric as String:  data as NSData,
             kSecValueData as String:    generator.secret as NSData,
             kSecAttrService as String:  kOTPService as NSString,
+            
+            // Allow keychain access in the background after first unlock.
+            kSecAttrAccessible as String:  kSecAttrAccessibleAfterFirstUnlock as NSString
         ]
     }
 }


### PR DESCRIPTION
•Added kSecAttrAccessible:kSecAttrAccessibleAfterFirstUnlock keychain attribute so tokens can be accessible in background after first unlock. This helps with apple watch notification response when device is locked.
•Also made the HMAC func public