### PR TITLE
Swift 5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ xcode_scheme: OneTimePassword (iOS)
 
 osx_image: xcode10.2
 
+before_install:
+- gem install cocoapods -v 1.7
+
 env:
   - RUNTIME="iOS 8.4"  DEVICE="iPhone 4s"
   - RUNTIME="iOS 9.3"  DEVICE="iPhone 6s"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: objective-c
 xcode_workspace: OneTimePassword.xcworkspace
 xcode_scheme: OneTimePassword (iOS)
 
-osx_image: xcode10.1
+osx_image: xcode10.2
 
 env:
   - RUNTIME="iOS 8.4"  DEVICE="iPhone 4s"

--- a/OneTimePassword.podspec
+++ b/OneTimePassword.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/mattrubin/OneTimePassword"
   s.license      = "MIT"
   s.author       = "Matt Rubin"
-  s.swift_version             = "4.2"
+  s.swift_versions            = ["4.2", "5.0"]
   s.ios.deployment_target     = "8.0"
   s.watchos.deployment_target = "2.0"
   s.source       = { :git => "https://github.com/mattrubin/OneTimePassword.git", :tag => s.version }

--- a/OneTimePassword.xcodeproj/project.pbxproj
+++ b/OneTimePassword.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 			buildSettings = {
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
@@ -695,7 +695,7 @@
 			buildSettings = {
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -34,11 +34,19 @@ func HMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
         macOut.deallocate()
     }
 
+    #if swift(>=5.0)
+    key.withUnsafeBytes { keyBytes in
+        data.withUnsafeBytes { dataBytes in
+            CCHmac(hashFunction, keyBytes.baseAddress, key.count, dataBytes.baseAddress, data.count, macOut)
+        }
+    }
+    #else
     key.withUnsafeBytes { keyBytes in
         data.withUnsafeBytes { dataBytes in
             CCHmac(hashFunction, keyBytes, key.count, dataBytes, data.count, macOut)
         }
     }
+    #endif
 
     return Data(bytes: macOut, count: hashLength)
 }


### PR DESCRIPTION
Add Swift 5 compatibility. The podspec declares compatibility with both the 4.2 and the 5.0 compiler via the new `swift_versions` directive which is available as of cocoapods v1.7.0.

Fixes #207