### PR TITLE
Created Package.swift with updated Base32 dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "OneTimePassword",
+    platforms: [
+      .iOS(.v13)
+    ],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "OneTimePassword",
+            targets: ["OneTimePassword"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+         .package(url: "https://github.com/norio-nomura/Base32", from: "0.5.4")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "OneTimePassword",
+            dependencies: ["Base32"],
+            path: "Sources")
+    ]
+)

--- a/Sources/Token+URL.swift
+++ b/Sources/Token+URL.swift
@@ -206,7 +206,7 @@ private func parseTimerPeriod(_ rawValue: String) throws -> TimeInterval {
 }
 
 private func parseSecret(_ rawValue: String) throws -> Data {
-    guard let secret = MF_Base32Codec.data(fromBase32String: rawValue) else {
+    guard let secret = base32DecodeToData(rawValue) else {
         throw DeserializationError.invalidSecret(rawValue)
     }
     return secret


### PR DESCRIPTION
This PR creates a `Package.swift` file for use with Xcode. It uses [a different Base32 dependency](https://github.com/norio-nomura/Base32) that is written in Swift (#135). CocoaPods and Carthage will have to switch to this dependency before this can be merged.