### PR TITLE
Drop support for Swift 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,16 +41,12 @@ matrix:
       env:
       before_script:
       script: carthage build --no-skip-current
-    - <<: *carthage
-      osx_image: xcode10.2
 
     # Build with CocoaPods
     - &cocoapods
       env:
       before_script:
       script: pod lib lint --allow-warnings --verbose
-    - <<: *cocoapods
-      osx_image: xcode10.2
 
 before_script:
   - DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,61 +5,51 @@ language: objective-c
 xcode_workspace: OneTimePassword.xcworkspace
 xcode_scheme: OneTimePassword (iOS)
 
-osx_image: xcode10.3
-
-before_install:
-- gem install cocoapods -v 1.7
+osx_image: xcode12.4
 
 env:
-  - RUNTIME="iOS 10.3" DEVICE="iPhone 7 Plus"
+  - RUNTIME="iOS 9.0" DEVICE="iPhone 4s"
+  - RUNTIME="iOS 10.3" DEVICE="iPhone 5s"
   - RUNTIME="iOS 11.4" DEVICE="iPhone X"
   - RUNTIME="iOS 12.4" DEVICE="iPhone XS Max"
+  - RUNTIME="iOS 13.7" DEVICE="iPhone 11"
+  - RUNTIME="iOS 14.3" DEVICE="iPhone 12 Mini"
 
 # Include builds for watchOS
 matrix:
   include:
+    # Build and test with Xcode 10.2 to ensure Swift 5.0 support.
+    - &xcode10.2
+      osx_image: xcode10.2
+      env: RUNTIME="iOS 12.2" DEVICE="iPhone 4s"
+
     # Include several build-only jobs for watchOS
     - xcode_scheme: OneTimePassword (watchOS)
-      env: BUILD_ONLY="YES" RUNTIME="watchOS 5.1" DEVICE="Apple Watch Series 4 - 44mm"
+      # The newest runtime and device:
+      env: BUILD_ONLY="YES" RUNTIME="watchOS 7.2" DEVICE="Apple Watch Series 6 - 44mm"
     - xcode_scheme: OneTimePassword (watchOS)
-      env: BUILD_ONLY="YES" RUNTIME="watchOS 4.2" DEVICE="Apple Watch Series 3 - 38mm"
-    - xcode_scheme: OneTimePassword (watchOS)
-      env: BUILD_ONLY="YES" RUNTIME="watchOS 3.2" DEVICE="Apple Watch Series 2 - 42mm"
+      # The oldest supported runtime and device:
+      env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
     - xcode_scheme: OneTimePassword (watchOS)
       osx_image: xcode10.2
-      env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
+      # The newest device an runtime supported by Xcode 10.2:
+      env: BUILD_ONLY="YES" RUNTIME="watchOS 5.2" DEVICE="Apple Watch Series 4 - 44mm"
+
     # Build with Carthage
-    - env:
+    - &carthage
+      env:
       before_script:
       script: carthage build --no-skip-current
+    - <<: *carthage
+      osx_image: xcode10.2
+
     # Build with CocoaPods
     - &cocoapods
       env:
       before_script:
       script: pod lib lint --allow-warnings --verbose
-    # Build with Xcode 10.1 and Swift 4.2
-    - &swift42
-      osx_image: xcode10.1
-      env: RUNTIME="iOS 9.0" DEVICE="iPhone 4s"
-      script: set -o pipefail && xcodebuild -workspace "$TRAVIS_XCODE_WORKSPACE" -scheme "$TRAVIS_XCODE_SCHEME" -destination "id=$DESTINATION_ID" SWIFT_VERSION=4.2 $ACTIONS | xcpretty -c
-    - <<: *swift42
-      env: RUNTIME="iOS 9.3" DEVICE="iPhone 6s"
-    # Build with CocoaPods and Swift 4.2
     - <<: *cocoapods
-      osx_image: xcode10.1
-      script: pod lib lint --allow-warnings --verbose --swift-version=4.2
-    - &xcode11
-      osx_image: xcode11
-      env: RUNTIME="iOS 13.0" DEVICE="iPhone XR"
-    - <<: *xcode11
-      env: RUNTIME="iOS 10.3" DEVICE="iPhone 5s"
-    - <<: *xcode11
-      xcode_scheme: OneTimePassword (watchOS)
-      env: BUILD_ONLY="YES" RUNTIME="watchOS 6.0" DEVICE="Apple Watch Series 4 - 40mm"
-    - <<: *xcode11
-      xcode_scheme: OneTimePassword (watchOS)
-      env: BUILD_ONLY="YES" RUNTIME="watchOS 3.2" DEVICE="Apple Watch Series 2 - 38mm"
-
+      osx_image: xcode10.2
 
 before_script:
   - DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,23 @@ xcode_scheme: OneTimePassword (iOS)
 osx_image: xcode12.4
 
 env:
-  - RUNTIME="iOS 9.0" DEVICE="iPhone 4s"
-  - RUNTIME="iOS 10.3" DEVICE="iPhone 5s"
-  - RUNTIME="iOS 11.4" DEVICE="iPhone X"
-  - RUNTIME="iOS 12.4" DEVICE="iPhone XS Max"
+  - RUNTIME="iOS 14.3" DEVICE="iPhone 12 mini"
   - RUNTIME="iOS 13.7" DEVICE="iPhone 11"
-  - RUNTIME="iOS 14.3" DEVICE="iPhone 12 Mini"
+  - RUNTIME="iOS 12.4" DEVICE="iPhone XS Max"
+  - RUNTIME="iOS 11.4" DEVICE="iPhone X"
 
 # Include builds for watchOS
 matrix:
   include:
+    # Build and test with Xcode 12.2 because it's the last pre-macOS 11 Travis image, with support for older iOS runtimes.
+    - &xcode12_2
+      osx_image: xcode12.2
+      env: RUNTIME="iOS 10.3" DEVICE="iPhone 5s"
+
     # Build and test with Xcode 10.2 to ensure Swift 5.0 support.
     - &xcode10_2
       osx_image: xcode10.2
-      env: RUNTIME="iOS 12.2" DEVICE="iPhone 4s"
+      env: RUNTIME="iOS 9.0" DEVICE="iPhone 4s"
 
     # Include several build-only jobs for watchOS
     - &watchos
@@ -29,12 +32,9 @@ matrix:
       # The newest runtime and device:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 7.2" DEVICE="Apple Watch Series 6 - 44mm"
     - <<: *watchos
+      osx_image: xcode10.2
       # The oldest supported runtime and device:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
-    - <<: *watchos
-      osx_image: xcode10.2
-      # The newest device an runtime supported by Xcode 10.2:
-      env: BUILD_ONLY="YES" RUNTIME="watchOS 5.2" DEVICE="Apple Watch Series 4 - 44mm"
 
     # Build with Carthage
     - &carthage

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,14 @@ matrix:
       env: RUNTIME="iOS 12.2" DEVICE="iPhone 4s"
 
     # Include several build-only jobs for watchOS
-    - xcode_scheme: OneTimePassword (watchOS)
+    - &watchos
+      xcode_scheme: OneTimePassword (watchOS)
       # The newest runtime and device:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 7.2" DEVICE="Apple Watch Series 6 - 44mm"
-    - xcode_scheme: OneTimePassword (watchOS)
+    - <<: *watchos
       # The oldest supported runtime and device:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
-    - xcode_scheme: OneTimePassword (watchOS)
+    - <<: *watchos
       osx_image: xcode10.2
       # The newest device an runtime supported by Xcode 10.2:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 5.2" DEVICE="Apple Watch Series 4 - 44mm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ matrix:
       osx_image: xcode12.2
       env: RUNTIME="iOS 10.3" DEVICE="iPhone 5s"
 
-    # Build and test with Xcode 10.2 to ensure Swift 5.0 support.
-    - &xcode10_2
-      osx_image: xcode10.2
-      env: RUNTIME="iOS 9.0" DEVICE="iPhone 4s"
+    # Build and test with Xcode 10.2 to ensure iOS 9 and Swift 5.0 support.
+    # - &xcode10_2
+    #   osx_image: xcode10.2
+    #   env: RUNTIME="iOS 9.0" DEVICE="iPhone 4s"
 
     # Include several build-only jobs for watchOS
     - &watchos

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 matrix:
   include:
     # Build and test with Xcode 10.2 to ensure Swift 5.0 support.
-    - &xcode10.2
+    - &xcode10_2
       osx_image: xcode10.2
       env: RUNTIME="iOS 12.2" DEVICE="iPhone 4s"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,5 +61,10 @@ script: set -o pipefail && xcodebuild -workspace "$TRAVIS_XCODE_WORKSPACE" -sche
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
+branches: 
+  only: 
+    - develop
+    - release
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
     - &carthage
       env:
       before_script:
-      script: carthage build --no-skip-current
+      script: carthage build --no-skip-current --platform iOS,watchOS --use-xcframeworks
 
     # Build with CocoaPods
     - &cocoapods

--- a/OneTimePassword.podspec
+++ b/OneTimePassword.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/mattrubin/OneTimePassword"
   s.license      = "MIT"
   s.author       = "Matt Rubin"
-  s.swift_versions            = ["4.2", "5.0"]
+  s.swift_versions            = "5.0"
   s.ios.deployment_target     = "9.0"
   s.watchos.deployment_target = "2.0"
   s.source       = { :git => "https://github.com/mattrubin/OneTimePassword.git", :tag => s.version }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Build Status](https://travis-ci.org/mattrubin/OneTimePassword.svg?branch=develop)](https://travis-ci.org/mattrubin/OneTimePassword)
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattrubin/OneTimePassword/develop.svg)](https://codecov.io/gh/mattrubin/OneTimePassword)
-[![Swift 4.2 or 5.0](https://img.shields.io/badge/swift-4.2%20%7C%205.0-orange.svg)](#usage)
+[![Swift 5](https://img.shields.io/badge/swift-5-orange.svg)](#usage)
 [![Available via Carthage and CocoaPods](https://img.shields.io/badge/via-Carthage%20%7C%20CocoaPods-MediumSlateBlue.svg)](#installation)
 ![Platforms: iOS, watchOS](https://img.shields.io/badge/platforms-iOS%20%7C%20watchOS-blue.svg)
 [![MIT License](https://img.shields.io/badge/license-MIT-lightgray.svg)](LICENSE.md)
@@ -52,7 +52,7 @@ Then run `pod install` to install the latest version of the framework.
 
 ## Usage
 
-> The [latest version][swift-5] of OneTimePassword can be compiled with either Swift 4.2 or Swift 5, and can be linked with Swift 4 or Swift 5 projects using the Swift compiler's [compatibility mode](https://swift.org/blog/swift-4-0-released/#new-compatibility-modes). To use OneTimePassword with earlier versions of Swift, check out the [`swift-4`][swift-4], [`swift-3`][swift-3], and [`swift-2.3`][swift-2.3] branches. To use OneTimePassword in an Objective-C based project, check out the [`objc` branch][objc] and the [1.x releases][releases].
+> The [latest version][swift-5] of OneTimePassword compiles with Swift 5. To use OneTimePassword with earlier versions of Swift, check out the [`swift-4.2`][swift-4.2], [`swift-4`][swift-4], [`swift-3`][swift-3], and [`swift-2.3`][swift-2.3] branches. To use OneTimePassword in an Objective-C based project, check out the [`objc` branch][objc] and the [1.x releases][releases].
 
 [swift-5]: https://github.com/mattrubin/OneTimePassword/tree/swift-5
 [swift-4.2]: https://github.com/mattrubin/OneTimePassword/tree/swift-4.2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Build Status](https://travis-ci.org/mattrubin/OneTimePassword.svg?branch=develop)](https://travis-ci.org/mattrubin/OneTimePassword)
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattrubin/OneTimePassword/develop.svg)](https://codecov.io/gh/mattrubin/OneTimePassword)
-[![Swift 5](https://img.shields.io/badge/swift-5-orange.svg)](#usage)
+[![Swift 5.x](https://img.shields.io/badge/swift-5.x-orange.svg)](#usage)
 [![Available via Carthage and CocoaPods](https://img.shields.io/badge/via-Carthage%20%7C%20CocoaPods-MediumSlateBlue.svg)](#installation)
 ![Platforms: iOS, watchOS](https://img.shields.io/badge/platforms-iOS%20%7C%20watchOS-blue.svg)
 [![MIT License](https://img.shields.io/badge/license-MIT-lightgray.svg)](LICENSE.md)


### PR DESCRIPTION
Swift 5.0 was released over two years ago, and Apple now requires apps submitted to the App Store to be built with Xcode 12, so it is extremely unlikely anyone using OneTimePassword still needs to compile it with Swift 4.2.

This PR also updates the Travis CI config to build with modern tools.