### PR TITLE
Require CryptoKit (Xcode 11+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ matrix:
       # The newest runtime and device:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 7.2" DEVICE="Apple Watch Series 6 - 44mm"
     - <<: *watchos
-      osx_image: xcode10.2
+      osx_image: xcode11
       # The oldest supported runtime and device:
-      env: BUILD_ONLY="YES" RUNTIME="watchOS 2.0" DEVICE="Apple Watch - 38mm"
+      env: BUILD_ONLY="YES" RUNTIME="watchOS 3.2" DEVICE="Apple Watch - 38mm"
 
     # Build with Carthage
     - &carthage

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -76,19 +76,11 @@ private func commonCryptoHMAC(algorithm: Generator.Algorithm, key: Data, data: D
         macOut.deallocate()
     }
 
-    #if swift(>=5.0)
     key.withUnsafeBytes { keyBytes in
         data.withUnsafeBytes { dataBytes in
             CCHmac(hashFunction, keyBytes.baseAddress, key.count, dataBytes.baseAddress, data.count, macOut)
         }
     }
-    #else
-    key.withUnsafeBytes { keyBytes in
-        data.withUnsafeBytes { dataBytes in
-            CCHmac(hashFunction, keyBytes, key.count, dataBytes, data.count, macOut)
-        }
-    }
-    #endif
 
     return Data(bytes: macOut, count: hashLength)
 }

--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -25,23 +25,16 @@
 
 import Foundation
 import CommonCrypto
-#if canImport(CryptoKit)
 import CryptoKit
-#endif
 
 func HMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
-    #if canImport(CryptoKit)
     if #available(iOS 13.0, macOS 10.15, watchOS 6.0, *) {
         return cryptoKitHMAC(algorithm: algorithm, key: key, data: data)
     } else {
         return commonCryptoHMAC(algorithm: algorithm, key: key, data: data)
     }
-    #else
-    return commonCryptoHMAC(algorithm: algorithm, key: key, data: data)
-    #endif
 }
 
-#if canImport(CryptoKit)
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, *)
 private func cryptoKitHMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
     let key = SymmetricKey(data: key)
@@ -73,7 +66,6 @@ private extension Generator.Algorithm {
         }
     }
 }
-#endif
 
 private func commonCryptoHMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
     let (hashFunction, hashLength) = algorithm.hashInfo

--- a/Sources/Generator.swift
+++ b/Sources/Generator.swift
@@ -86,7 +86,6 @@ public struct Generator: Equatable {
         let counterData = Data(bytes: &bigCounter, count: MemoryLayout<UInt64>.size)
         let hash = HMAC(algorithm: algorithm, key: secret, data: counterData)
 
-        #if swift(>=5.0)
         var truncatedHash = hash.withUnsafeBytes { ptr -> UInt32 in
             // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
             let offset = ptr[hash.count - 1] & 0x0f
@@ -95,18 +94,6 @@ public struct Generator: Equatable {
             let truncatedHashPtr = ptr.baseAddress! + Int(offset)
             return truncatedHashPtr.bindMemory(to: UInt32.self, capacity: 1).pointee
         }
-        #else
-        var truncatedHash = hash.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> UInt32 in
-            // Use the last 4 bits of the hash as an offset (0 <= offset <= 15)
-            let offset = ptr[hash.count - 1] & 0x0f
-
-            // Take 4 bytes from the hash, starting at the given byte offset
-            let truncatedHashPtr = ptr + Int(offset)
-            return truncatedHashPtr.withMemoryRebound(to: UInt32.self, capacity: 1) {
-                $0.pointee
-            }
-        }
-        #endif
 
         // Ensure the four bytes taken from the hash match the current endian format
         truncatedHash = UInt32(bigEndian: truncatedHash)


### PR DESCRIPTION
The CryptoKit library was introduced with iOS 13, so every version of Xcode with the iOS 13+ SDK (Xcode 11+) can build code that imports CryptoKit. This change doesn't affect OneTimePassword's runtime support for earlier iOS versions, because the runtime check and CommonCrypto fallback remain.

Also, delete pre-Swift 5.0 code paths that should have been removed in the previous PR.