### PR TITLE
Configure GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         xcrun simctl boot $DESTINATION_ID
         set -o pipefail
         xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
+    - uses: codecov/codecov-action@v1
 
   xcode-watchos:
     name: "Xcode ${{ matrix.env.xcode }}, ${{ matrix.env.runtime }}, ${{ matrix.env.device }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,20 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
     - name: "Build"
       run: carthage build --no-skip-current --use-xcframeworks --no-use-binaries
+
+  cocoapods:
+    name: "CocoaPods"
+    runs-on: macOS-10.15
+    strategy:
+      matrix:
+        env:
+          - xcode: 12.4
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: "Upgrade CocoaPods"
+      run: sudo gem install cocoapods
+    - name: "Select Xcode ${{ matrix.env.xcode }}"
+      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
+    - run: pod lib lint --allow-warnings --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         DEVICE="${{ matrix.env.device }}"
         DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
         RUNTIME_ID=com.apple.CoreSimulator.SimRuntime.$(echo $RUNTIME | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
-        DESTINATION_ID=$(xcrun simctl create Travis $DEVICE_ID $RUNTIME_ID)
+        DESTINATION_ID=$(xcrun simctl create "Custom: $DEVICE, $RUNTIME" $DEVICE_ID $RUNTIME_ID)
         xcrun simctl boot $DESTINATION_ID
         set -o pipefail
         xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
@@ -62,7 +62,7 @@ jobs:
         DEVICE="${{ matrix.env.device }}"
         DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
         RUNTIME_ID=com.apple.CoreSimulator.SimRuntime.$(echo $RUNTIME | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
-        DESTINATION_ID=$(xcrun simctl create Travis $DEVICE_ID $RUNTIME_ID)
+        DESTINATION_ID=$(xcrun simctl create "Custom: $DEVICE, $RUNTIME" $DEVICE_ID $RUNTIME_ID)
         set -o pipefail
         xcodebuild build -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (watchOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Xcode
+name: CI
 
 on: [push]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
     - name: "Select Xcode ${{ matrix.env.xcode }}"
       run: sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
     - name: "Build"
-      run: carthage build --archive --use-xcframeworks
+      run: carthage build --archive --use-xcframeworks --no-use-binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,37 @@ jobs:
         set -o pipefail
         xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
 
+  xcode-watchos:
+    name: "Xcode / watchOS"
+    runs-on: macOS-10.15
+    strategy:
+      matrix:
+        env:
+          - xcode: 12.4
+            runtime: "watchOS 7.2"
+            device: "Apple Watch Series 6 - 44mm"
+          - xcode: 11.2.1
+            runtime: "watchOS 6.1"
+            device: "Apple Watch Series 4 - 40mm"
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: "Select Xcode ${{ matrix.env.xcode }}"
+      run: |
+        sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
+        xcodebuild -version -sdk
+        xcrun simctl list
+    - name: "Build"
+      run: |
+        RUNTIME="${{ matrix.env.runtime }}"
+        DEVICE="${{ matrix.env.device }}"
+        DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
+        RUNTIME_ID=com.apple.CoreSimulator.SimRuntime.$(echo $RUNTIME | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
+        DESTINATION_ID=$(xcrun simctl create Travis $DEVICE_ID $RUNTIME_ID)
+        set -o pipefail
+        xcodebuild build -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (watchOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
+
   carthage:
     name: "Carthage"
     runs-on: macOS-10.15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   xcode-ios:
-    name: "Xcode / iOS"
+    name: "Xcode ${{ matrix.env.xcode }}, ${{ matrix.env.runtime }}, ${{ matrix.env.device }}"
     runs-on: macOS-10.15
     strategy:
       matrix:
@@ -36,7 +36,7 @@ jobs:
         xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
 
   xcode-watchos:
-    name: "Xcode / watchOS"
+    name: "Xcode ${{ matrix.env.xcode }}, ${{ matrix.env.runtime }}, ${{ matrix.env.device }}"
     runs-on: macOS-10.15
     strategy:
       matrix:
@@ -67,7 +67,7 @@ jobs:
         xcodebuild build -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (watchOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
 
   carthage:
-    name: "Carthage"
+    name: "Carthage, Xcode ${{ matrix.env.xcode }}"
     runs-on: macOS-10.15
     strategy:
       matrix:
@@ -85,7 +85,7 @@ jobs:
       run: carthage build --no-skip-current --use-xcframeworks --no-use-binaries
 
   cocoapods:
-    name: "CocoaPods"
+    name: "CocoaPods, Xcode ${{ matrix.env.xcode }}"
     runs-on: macOS-10.15
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: 'Select Xcode ${{ matrix.env.xcode }}'
+    - name: "Select Xcode ${{ matrix.env.xcode }}"
       run: |
         sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
         xcodebuild -version -sdk
@@ -47,8 +47,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: 'Select Xcode ${{ matrix.env.xcode }}'
-      run: |
-        sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
+    - name: "Upgrade Carthage"
+      run: brew upgrade carthage
+    - name: "Select Xcode ${{ matrix.env.xcode }}"
+      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
     - name: "Build"
       run: carthage build --archive --use-xcframeworks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,21 @@ jobs:
         xcrun simctl boot $DESTINATION_ID
         set -o pipefail
         xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
+
+  carthage:
+    name: "Carthage"
+    runs-on: macOS-10.15
+    strategy:
+      matrix:
+        env:
+          - xcode: 12.4
+          - xcode: 11.7
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: 'Select Xcode ${{ matrix.env.xcode }}'
+      run: |
+        sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
+    - name: "Build"
+      run: carthage build --archive --use-xcframeworks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,4 @@ jobs:
     - name: "Select Xcode ${{ matrix.env.xcode }}"
       run: sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
     - name: "Build"
-      run: carthage build --archive --use-xcframeworks --no-use-binaries
+      run: carthage build --no-skip-current --use-xcframeworks --no-use-binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
           - xcode: 12.4
             runtime: "iOS 14.4"
             device: "iPhone 12 Pro Max"
-          - xcode: 11.7
-            runtime: "iOS 13.7"
+          - xcode: 11.2.1
+            runtime: "iOS 13.2"
             device: "iPhone 6s"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
       matrix:
         env:
           - xcode: 12.4
-          - xcode: 11.7
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,41 @@ jobs:
         xcrun simctl boot $DESTINATION_ID
         set -o pipefail
         xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
+
+  xcodebuild-xcode-10-3-swift-5-ios:
+    name: "xcodebuild, Xcode 10.3, Swift 5, iOS"
+    runs-on: macOS-10.14
+    strategy:
+      matrix:
+        destination:
+          - name=iPhone 5,OS=10.1
+          - name=iPhone Xʀ,OS=12.4
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: 'Select Xcode 10.3'
+      run: sudo xcode-select -s /Applications/Xcode_10.3.app
+    - name: "Build and Test"
+      run: |
+        set -o pipefail
+        xcodebuild test SWIFT_VERSION=5 -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,${{ matrix.destination }}" | xcpretty -c
+
+  xcodebuild-xcode-10-3-swift-4-2-ios:
+    name: "xcodebuild, Xcode 10.3, Swift 4.2, iOS"
+    runs-on: macOS-10.14
+    strategy:
+      matrix:
+        destination:
+          - name=iPhone 5,OS=10.1
+          - name=iPhone Xʀ,OS=12.4
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: 'Select Xcode 10.3'
+      run: sudo xcode-select -s /Applications/Xcode_10.3.app
+    - name: "Build and Test"
+      run: |
+        set -o pipefail
+        xcodebuild test SWIFT_VERSION=4.2 -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,${{ matrix.destination }}" | xcpretty -c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,11 @@ jobs:
       matrix:
         env:
           - xcode: 12.4
-            ios: 14.4
+            runtime: "iOS 14.4"
+            device: "iPhone 12 Pro Max"
           - xcode: 11.7
-            ios: 13.7
+            runtime: "iOS 13.7"
+            device: "iPhone 6s"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -24,5 +26,11 @@ jobs:
         xcrun simctl list
     - name: "Build and Test"
       run: |
+        RUNTIME="${{ matrix.env.runtime }}"
+        DEVICE="${{ matrix.env.device }}"
+        DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
+        RUNTIME_ID=com.apple.CoreSimulator.SimRuntime.$(echo $RUNTIME | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
+        DESTINATION_ID=$(xcrun simctl create Travis $DEVICE_ID $RUNTIME_ID)
+        xcrun simctl boot $DESTINATION_ID
         set -o pipefail
-        xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,OS=${{ matrix.env.ios }}" | xcpretty -c
+        xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ jobs:
   xcodebuild-swift-5-ios:
     name: "xcodebuild, Xcode 10.3, iOS"
     runs-on: macOS-10.14
+    strategy:
+      matrix:
+        destination:
+          - name=iPhone 7 Plus,OS=10.3
+          - name=iPhone X,OS=11.4
+          - name=iPhone XS Max,OS=12.4
     steps:
     - uses: actions/checkout@v1
       with:
@@ -15,4 +21,4 @@ jobs:
     - name: "Build and Test"
       run: |
         set -o pipefail
-        xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,name=iPhone X" | xcpretty -c
+        xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,${{ matrix.destination }}" | xcpretty -c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       matrix:
         env:
-          - RUNTIME="iOS 10.0" DEVICE="iPhone SE"
-          - RUNTIME="iOS 10.2" DEVICE="iPhone 7 Plus"
-          - RUNTIME="iOS 12.4" DEVICE="iPhone XS Max"
+          - RUNTIME="iOS 14.4" DEVICE="iPhone SE"
+          - RUNTIME="iOS 14.4" DEVICE="iPhone 7 Plus"
+          - RUNTIME="iOS 14.4" DEVICE="iPhone XS Max"
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - name: 'Select Xcode 12.4'
@@ -37,10 +37,10 @@ jobs:
     strategy:
       matrix:
         destination:
-          - name=iPhone 5,OS=10.1
-          - name=iPhone Xʀ,OS=12.4
+          - name=iPhone 5,OS=14.4
+          - name=iPhone Xʀ,OS=14.4
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - name: 'Select Xcode 12.4'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: macOS-10.14
     strategy:
       matrix:
-        destination:
-          - name=iPhone 7 Plus,OS=10.3
-          - name=iPhone X,OS=11.4
-          - name=iPhone XS Max,OS=12.4
+        env:
+          - RUNTIME="iOS 10.0" DEVICE="iPhone SE"
+          - RUNTIME="iOS 10.2" DEVICE="iPhone 7 Plus"
+          - RUNTIME="iOS 12.4" DEVICE="iPhone XS Max"
     steps:
     - uses: actions/checkout@v1
       with:
@@ -20,5 +20,10 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_10.3.app
     - name: "Build and Test"
       run: |
+        ${{ matrix.env }}
+        DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
+        RUNTIME_ID=com.apple.CoreSimulator.SimRuntime.$(echo $RUNTIME | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
+        DESTINATION_ID=$(xcrun simctl create Travis $DEVICE_ID $RUNTIME_ID)
+        xcrun simctl boot $DESTINATION_ID
         set -o pipefail
-        xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,${{ matrix.destination }}" | xcpretty -c
+        xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on: [push]
+
+jobs:
+  xcodebuild-swift-5-ios:
+    name: "xcodebuild, Xcode 10.3, iOS"
+    runs-on: macOS-10.14
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: 'Select Xcode 10.3'
+      run: sudo xcode-select -s /Applications/Xcode_10.3.app
+    - name: "Build and Test"
+      run: |
+        set -o pipefail
+        xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,name=iPhone X" | xcpretty -c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,10 @@
-name: CI
+name: Xcode
 
 on: [push]
 
 jobs:
-  xcodebuild-swift-5-ios:
-    name: "xcodebuild, Xcode 10.3, iOS"
+  xcode-10-3-ios:
+    name: "Xcode 10.3, iOS"
     runs-on: macOS-10.14
     strategy:
       matrix:
@@ -28,8 +28,8 @@ jobs:
         set -o pipefail
         xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
 
-  xcodebuild-xcode-10-3-swift-5-ios:
-    name: "xcodebuild, Xcode 10.3, Swift 5, iOS"
+  xcode-10-3-swift-5-ios:
+    name: "Xcode 10.3, Swift 5, iOS"
     runs-on: macOS-10.14
     strategy:
       matrix:
@@ -47,8 +47,8 @@ jobs:
         set -o pipefail
         xcodebuild test SWIFT_VERSION=5 -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,${{ matrix.destination }}" | xcpretty -c
 
-  xcodebuild-xcode-10-3-swift-4-2-ios:
-    name: "xcodebuild, Xcode 10.3, Swift 4.2, iOS"
+  xcode-10-3-swift-4-2-ios:
+    name: "Xcode 10.3, Swift 4.2, iOS"
     runs-on: macOS-10.14
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       matrix:
         env:
-          - RUNTIME: "iOS 14.4"
-            DEVICE: "iPhone SE"
-          - RUNTIME: "iOS 14.4"
-            DEVICE: "iPhone 7 Plus"
-          - RUNTIME: "iOS 14.4"
-            DEVICE: "iPhone XS Max"
+          - runtime: "iOS 14.4"
+            device: "iPhone SE"
+          - runtime: "iOS 14.4"
+            device: "iPhone 7 Plus"
+          - runtime: "iOS 14.4"
+            device: "iPhone XS Max"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -26,7 +26,8 @@ jobs:
         xcrun simctl list
     - name: "Build and Test"
       run: |
-        ${{ matrix.env }}
+        RUNTIME="${{ matrix.env.runtime }}"
+        DEVICE="${{ matrix.env.device }}"
         DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
         RUNTIME_ID=com.apple.CoreSimulator.SimRuntime.$(echo $RUNTIME | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
         DESTINATION_ID=$(xcrun simctl create Travis $DEVICE_ID $RUNTIME_ID)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Xcode
 on: [push]
 
 jobs:
-  xcode-10-3-ios:
-    name: "Xcode 10.3, iOS"
-    runs-on: macOS-10.14
+  xcode-12-4-ios:
+    name: "Xcode 12.4, iOS"
+    runs-on: macOS-10.15
     strategy:
       matrix:
         env:
@@ -16,8 +16,11 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
-    - name: 'Select Xcode 10.3'
-      run: sudo xcode-select -s /Applications/Xcode_10.3.app
+    - name: 'Select Xcode 12.4'
+      run: |
+        sudo xcode-select -s /Applications/Xcode_12.4.app
+        xcodebuild -version -sdk
+        xcrun simctl list
     - name: "Build and Test"
       run: |
         ${{ matrix.env }}
@@ -28,9 +31,9 @@ jobs:
         set -o pipefail
         xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
 
-  xcode-10-3-swift-5-ios:
-    name: "Xcode 10.3, Swift 5, iOS"
-    runs-on: macOS-10.14
+  xcode-12-4-swift-5-ios:
+    name: "Xcode 12.4, Swift 5, iOS"
+    runs-on: macOS-10.15
     strategy:
       matrix:
         destination:
@@ -40,28 +43,12 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
-    - name: 'Select Xcode 10.3'
-      run: sudo xcode-select -s /Applications/Xcode_10.3.app
+    - name: 'Select Xcode 12.4'
+      run: |
+        sudo xcode-select -s /Applications/Xcode_12.4.app
+        xcodebuild -version -sdk
+        xcrun simctl list
     - name: "Build and Test"
       run: |
         set -o pipefail
         xcodebuild test SWIFT_VERSION=5 -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,${{ matrix.destination }}" | xcpretty -c
-
-  xcode-10-3-swift-4-2-ios:
-    name: "Xcode 10.3, Swift 4.2, iOS"
-    runs-on: macOS-10.14
-    strategy:
-      matrix:
-        destination:
-          - name=iPhone 5,OS=10.1
-          - name=iPhone Xʀ,OS=12.4
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: recursive
-    - name: 'Select Xcode 10.3'
-      run: sudo xcode-select -s /Applications/Xcode_10.3.app
-    - name: "Build and Test"
-      run: |
-        set -o pipefail
-        xcodebuild test SWIFT_VERSION=4.2 -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,${{ matrix.destination }}" | xcpretty -c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,9 @@ jobs:
       matrix:
         env:
           - xcode: 12.4
-            runtime: "iOS 14.4"
-            device: "iPhone SE"
+            ios: 14.4
           - xcode: 11.7
-            runtime: "iOS 13.7"
-            device: "iPhone 8 Plus"
-          - xcode: 10.3
-            runtime: "iOS 12.4"
-            device: "iPhone XS Max"
+            ios: 13.7
     steps:
     - uses: actions/checkout@v2
       with:
@@ -29,11 +24,5 @@ jobs:
         xcrun simctl list
     - name: "Build and Test"
       run: |
-        RUNTIME="${{ matrix.env.runtime }}"
-        DEVICE="${{ matrix.env.device }}"
-        DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
-        RUNTIME_ID=com.apple.CoreSimulator.SimRuntime.$(echo $RUNTIME | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
-        DESTINATION_ID=$(xcrun simctl create Travis $DEVICE_ID $RUNTIME_ID)
-        xcrun simctl boot $DESTINATION_ID
         set -o pipefail
-        xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
+        xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,OS=${{ matrix.env.ios }}" | xcpretty -c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,18 @@ name: Xcode
 on: [push]
 
 jobs:
-  xcode-12-4-ios:
-    name: "Xcode 12.4, iOS"
+  xcode-ios:
+    name: "Xcode / iOS"
     runs-on: macOS-10.15
     strategy:
       matrix:
         env:
-          - RUNTIME="iOS 14.4" DEVICE="iPhone SE"
-          - RUNTIME="iOS 14.4" DEVICE="iPhone 7 Plus"
-          - RUNTIME="iOS 14.4" DEVICE="iPhone XS Max"
+          - RUNTIME: "iOS 14.4"
+            DEVICE: "iPhone SE"
+          - RUNTIME: "iOS 14.4"
+            DEVICE: "iPhone 7 Plus"
+          - RUNTIME: "iOS 14.4"
+            DEVICE: "iPhone XS Max"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -30,25 +33,3 @@ jobs:
         xcrun simctl boot $DESTINATION_ID
         set -o pipefail
         xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=$DESTINATION_ID" | xcpretty -c
-
-  xcode-12-4-swift-5-ios:
-    name: "Xcode 12.4, Swift 5, iOS"
-    runs-on: macOS-10.15
-    strategy:
-      matrix:
-        destination:
-          - name=iPhone 5,OS=14.4
-          - name=iPhone Xʀ,OS=14.4
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: 'Select Xcode 12.4'
-      run: |
-        sudo xcode-select -s /Applications/Xcode_12.4.app
-        xcodebuild -version -sdk
-        xcrun simctl list
-    - name: "Build and Test"
-      run: |
-        set -o pipefail
-        xcodebuild test SWIFT_VERSION=5 -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "platform=iOS Simulator,${{ matrix.destination }}" | xcpretty -c

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,19 +9,22 @@ jobs:
     strategy:
       matrix:
         env:
-          - runtime: "iOS 14.4"
+          - xcode: 12.4
+            runtime: "iOS 14.4"
             device: "iPhone SE"
-          - runtime: "iOS 14.4"
-            device: "iPhone 7 Plus"
-          - runtime: "iOS 14.4"
+          - xcode: 11.7
+            runtime: "iOS 13.7"
+            device: "iPhone 8 Plus"
+          - xcode: 10.3
+            runtime: "iOS 12.4"
             device: "iPhone XS Max"
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: 'Select Xcode 12.4'
+    - name: 'Select Xcode ${{ matrix.env.xcode }}'
       run: |
-        sudo xcode-select -s /Applications/Xcode_12.4.app
+        sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
         xcodebuild -version -sdk
         xcrun simctl list
     - name: "Build and Test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,18 +36,6 @@ matrix:
       # The oldest supported runtime and device:
       env: BUILD_ONLY="YES" RUNTIME="watchOS 3.2" DEVICE="Apple Watch - 38mm"
 
-    # Build with Carthage
-    - &carthage
-      env:
-      before_script:
-      script: carthage build --no-skip-current --platform iOS,watchOS --use-xcframeworks
-
-    # Build with CocoaPods
-    - &cocoapods
-      env:
-      before_script:
-      script: pod lib lint --allow-warnings --verbose
-
 before_script:
   - DEVICE_ID=com.apple.CoreSimulator.SimDeviceType.$(echo $DEVICE | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
   - RUNTIME_ID=com.apple.CoreSimulator.SimRuntime.$(echo $RUNTIME | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")


### PR DESCRIPTION
Also, delete the Carthage and CocoaPods jobs from the Travis config, since Travis CI's free credits for OSS are a hard-to-come-by resource, and those exact configurations are covered by GitHub Actions.