### PR TITLE
Migrate more CI jobs from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
             runtime: "iOS 14.4"
             device: "iPhone 12 Pro Max"
           - xcode: 12.4
-            runtime: "iOS 13.2"
-            device: "iPhone 6s"
+            runtime: "iOS 13.7"
+            device: "iPhone 11"
           - xcode: 12.4
             runtime: "iOS 12.4"
-            device: "iPhone XS Max"
+            device: "iPhone 5s"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -26,7 +26,7 @@ jobs:
       run: |
         sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
         sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 12.4.simruntime
-        sudo ln -s /Applications/Xcode_11.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 13.2.simruntime
+        sudo ln -s /Applications/Xcode_11.7.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 13.7.simruntime
     - name: "Select Xcode ${{ matrix.env.xcode }}"
       run: |
         sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
@@ -54,8 +54,11 @@ jobs:
             runtime: "watchOS 7.2"
             device: "Apple Watch Series 6 - 44mm"
           - xcode: 12.4
-            runtime: "watchOS 6.1"
+            runtime: "watchOS 6.2"
             device: "Apple Watch Series 4 - 40mm"
+          - xcode: 12.4
+            runtime: "watchOS 5.3"
+            device: "Apple Watch Series 2 - 38mm"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -63,7 +66,8 @@ jobs:
     - name: Link simulator runtimes
       run: |
         sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
-        sudo ln -s /Applications/Xcode_11.3.1.app/Contents/Developer/Platforms/WatchOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/watchOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/watchOS\ 6.1.simruntime
+        sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/WatchOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/watchOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/watchOS\ 5.2.simruntime
+        sudo ln -s /Applications/Xcode_11.7.app/Contents/Developer/Platforms/WatchOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/watchOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/watchOS\ 6.2.simruntime
     - name: "Select Xcode ${{ matrix.env.xcode }}"
       run: |
         sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           - xcode: 12.4
             runtime: "iOS 14.4"
             device: "iPhone 12 Pro Max"
-          - xcode: 11.2.1
+          - xcode: 12.4
             runtime: "iOS 13.2"
             device: "iPhone 6s"
           - xcode: 12.4
@@ -22,11 +22,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: Link iOS 12.4 runtime
-      if: ${{ matrix.env.runtime == 'iOS 12.4' }}
+    - name: Link simulator runtimes
       run: |
         sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
         sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 12.4.simruntime
+        sudo ln -s /Applications/Xcode_11.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 13.2.simruntime
     - name: "Select Xcode ${{ matrix.env.xcode }}"
       run: |
         sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app
@@ -53,13 +53,17 @@ jobs:
           - xcode: 12.4
             runtime: "watchOS 7.2"
             device: "Apple Watch Series 6 - 44mm"
-          - xcode: 11.2.1
+          - xcode: 12.4
             runtime: "watchOS 6.1"
             device: "Apple Watch Series 4 - 40mm"
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+    - name: Link simulator runtimes
+      run: |
+        sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
+        sudo ln -s /Applications/Xcode_11.3.1.app/Contents/Developer/Platforms/WatchOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/watchOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/watchOS\ 6.1.simruntime
     - name: "Select Xcode ${{ matrix.env.xcode }}"
       run: |
         sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,18 @@ jobs:
           - xcode: 11.2.1
             runtime: "iOS 13.2"
             device: "iPhone 6s"
+          - xcode: 12.4
+            runtime: "iOS 12.4"
+            device: "iPhone XS Max"
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+    - name: Link iOS 12.4 runtime
+      if: ${{ matrix.env.runtime == 'iOS 12.4' }}
+      run: |
+        sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
+        sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 12.4.simruntime
     - name: "Select Xcode ${{ matrix.env.xcode }}"
       run: |
         sudo xcode-select -s /Applications/Xcode_${{ matrix.env.xcode }}.app

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ osx_image: xcode12.4
 env:
   - RUNTIME="iOS 14.3" DEVICE="iPhone 12 mini"
   - RUNTIME="iOS 13.7" DEVICE="iPhone 11"
-  - RUNTIME="iOS 12.4" DEVICE="iPhone XS Max"
   - RUNTIME="iOS 11.4" DEVICE="iPhone X"
 
 # Include builds for watchOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ xcode_scheme: OneTimePassword (iOS)
 osx_image: xcode12.4
 
 env:
-  - RUNTIME="iOS 14.3" DEVICE="iPhone 12 mini"
-  - RUNTIME="iOS 13.7" DEVICE="iPhone 11"
   - RUNTIME="iOS 11.4" DEVICE="iPhone X"
 
 # Include builds for watchOS
@@ -28,8 +26,9 @@ matrix:
     # Include several build-only jobs for watchOS
     - &watchos
       xcode_scheme: OneTimePassword (watchOS)
-      # The newest runtime and device:
-      env: BUILD_ONLY="YES" RUNTIME="watchOS 7.2" DEVICE="Apple Watch Series 6 - 44mm"
+      # Build with Xcode 12.2 because it's the last pre-macOS 11 Travis image, with support for older watchOS runtimes.
+      osx_image: xcode12.2
+      env: BUILD_ONLY="YES" RUNTIME="watchOS 4.2" DEVICE="Apple Watch Series 3 - 42mm"
     - <<: *watchos
       osx_image: xcode11
       # The oldest supported runtime and device:


### PR DESCRIPTION
On GitHub actions, build and test on the latest release of each major version of iOS and watchOS.
Do the same on Travis, for older versions not supported by GitHub Actions.