### PR TITLE
Upgrade the Base32 version used by Carthage to match the SPM version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 # Configuration for Carthage (https://github.com/Carthage/Carthage)
 
-github "mattrubin/Base32" "1.1.2+xcode10.2"
+github "mattrubin/Base32" "1.1.2+spm"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "jspahrsummers/xcconfigs" "1.1"
-github "mattrubin/Base32" "1.1.2+xcode10.2"
+github "mattrubin/Base32" "1.1.2+spm"


### PR DESCRIPTION
This update also includes recommended build settings changes for Xcode 12.4