### PR TITLE
Simplify the conversion from `HashedAuthenticationCode` to `Data`

### DIFF
--- a/Sources/Crypto.swift
+++ b/Sources/Crypto.swift
@@ -39,31 +39,13 @@ func HMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
 private func cryptoKitHMAC(algorithm: Generator.Algorithm, key: Data, data: Data) -> Data {
     let key = SymmetricKey(data: key)
 
-    func createData(_ ptr: UnsafeRawBufferPointer) -> Data {
-        Data(bytes: ptr.baseAddress!, count: algorithm.hashLength)
-    }
-
     switch algorithm {
     case .sha1:
-        return CryptoKit.HMAC<Insecure.SHA1>.authenticationCode(for: data, using: key).withUnsafeBytes(createData)
+        return Data(CryptoKit.HMAC<Insecure.SHA1>.authenticationCode(for: data, using: key))
     case .sha256:
-        return CryptoKit.HMAC<SHA256>.authenticationCode(for: data, using: key).withUnsafeBytes(createData)
+        return Data(CryptoKit.HMAC<SHA256>.authenticationCode(for: data, using: key))
     case .sha512:
-        return CryptoKit.HMAC<SHA512>.authenticationCode(for: data, using: key).withUnsafeBytes(createData)
-    }
-}
-
-@available(iOS 13.0, macOS 10.15, watchOS 6.0, *)
-private extension Generator.Algorithm {
-    var hashLength: Int {
-        switch self {
-        case .sha1:
-            return Insecure.SHA1.byteCount
-        case .sha256:
-            return SHA256.byteCount
-        case .sha512:
-            return SHA512.byteCount
-        }
+        return Data(CryptoKit.HMAC<SHA512>.authenticationCode(for: data, using: key))
     }
 }
 


### PR DESCRIPTION
`HashedAuthenticationCode` conforms to `Sequence<UInt8>`, so it can be passed directly into `Data.init` without needing to use unsafe bytes.