### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/carthage.yml
+++ b/.github/workflows/carthage.yml
@@ -11,14 +11,14 @@ jobs:
         env:
           - xcode: 13.4
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: "Upgrade Carthage"
-      run: brew upgrade carthage
-    - name: "Select Xcode ${{ matrix.env.xcode }}"
-      uses: ./.github/actions/xcode-select
-      with: 
-        version: ${{ matrix.env.xcode }}
-    - name: "Build"
-      run: carthage build --no-skip-current --use-xcframeworks --no-use-binaries
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: "Upgrade Carthage"
+        run: brew upgrade carthage
+      - name: "Select Xcode ${{ matrix.env.xcode }}"
+        uses: ./.github/actions/xcode-select
+        with:
+          version: ${{ matrix.env.xcode }}
+      - name: "Build"
+        run: carthage build --no-skip-current --use-xcframeworks --no-use-binaries

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -11,9 +11,9 @@ jobs:
         env:
           - xcode: 13.4
     steps:
-    - uses: actions/checkout@v2
-    - name: "Select Xcode ${{ matrix.env.xcode }}"
-      uses: ./.github/actions/xcode-select
-      with: 
-        version: ${{ matrix.env.xcode }}
-    - run: swift test
+      - uses: actions/checkout@v3
+      - name: "Select Xcode ${{ matrix.env.xcode }}"
+        uses: ./.github/actions/xcode-select
+        with:
+          version: ${{ matrix.env.xcode }}
+      - run: swift test

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -19,34 +19,34 @@ jobs:
             runtime: "iOS 13.7"
             device: "iPhone 11"
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-    - name: "Select Xcode ${{ matrix.env.xcode }}"
-      uses: ./.github/actions/xcode-select
-      with: 
-        version: ${{ matrix.env.xcode }}
-    - name: "Cache downloaded simulator runtimes"
-      uses: actions/cache@v3
-      with:
-        path: ~/Library/Caches/XcodeInstall/*.dmg
-        key: Xcode ${{ matrix.env.xcode }}+${{ matrix.env.runtime }}
-    - name: "Prepare simulator"
-      id: prepare-simulator
-      uses: ./.github/actions/prepare-simulator
-      with: 
-        runtime: ${{ matrix.env.runtime }}
-        device: ${{ matrix.env.device }}
-    - name: "Build and test"
-      run: |
-        set -o pipefail
-        xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=${{ steps.prepare-simulator.outputs.destination-id }}" | xcpretty -c
-    - uses: sersoft-gmbh/swift-coverage-action@v2
-      with:
-        target-name-filter: ^OneTimePassword$
-    - uses: codecov/codecov-action@v3
-      with:
-        fail_ci_if_error: true
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: "Select Xcode ${{ matrix.env.xcode }}"
+        uses: ./.github/actions/xcode-select
+        with:
+          version: ${{ matrix.env.xcode }}
+      - name: "Cache downloaded simulator runtimes"
+        uses: actions/cache@v3
+        with:
+          path: ~/Library/Caches/XcodeInstall/*.dmg
+          key: Xcode ${{ matrix.env.xcode }}+${{ matrix.env.runtime }}
+      - name: "Prepare simulator"
+        id: prepare-simulator
+        uses: ./.github/actions/prepare-simulator
+        with:
+          runtime: ${{ matrix.env.runtime }}
+          device: ${{ matrix.env.device }}
+      - name: "Build and test"
+        run: |
+          set -o pipefail
+          xcodebuild test -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (iOS)" -destination "id=${{ steps.prepare-simulator.outputs.destination-id }}" | xcpretty -c
+      - uses: sersoft-gmbh/swift-coverage-action@v3
+        with:
+          target-name-filter: ^OneTimePassword$
+      - uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
 
   watchos:
     name: "Xcode ${{ matrix.env.xcode }}, ${{ matrix.env.runtime }}, ${{ matrix.env.device }}"
@@ -64,25 +64,25 @@ jobs:
             runtime: "watchOS 6.2"
             device: "Apple Watch Series 4 - 40mm"
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-    - name: "Select Xcode ${{ matrix.env.xcode }}"
-      uses: ./.github/actions/xcode-select
-      with: 
-        version: ${{ matrix.env.xcode }}
-    - name: "Cache downloaded simulator runtimes"
-      uses: actions/cache@v3
-      with:
-        path: ~/Library/Caches/XcodeInstall/*.dmg
-        key: Xcode ${{ matrix.env.xcode }}+${{ matrix.env.runtime }}
-    - name: "Prepare simulator"
-      id: prepare-simulator
-      uses: ./.github/actions/prepare-simulator
-      with: 
-        runtime: ${{ matrix.env.runtime }}
-        device: ${{ matrix.env.device }}
-    - name: "Build"
-      run: |
-        set -o pipefail
-        xcodebuild build -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (watchOS)" -destination "id=${{ steps.prepare-simulator.outputs.destination-id }}" | xcpretty -c
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: "Select Xcode ${{ matrix.env.xcode }}"
+        uses: ./.github/actions/xcode-select
+        with:
+          version: ${{ matrix.env.xcode }}
+      - name: "Cache downloaded simulator runtimes"
+        uses: actions/cache@v3
+        with:
+          path: ~/Library/Caches/XcodeInstall/*.dmg
+          key: Xcode ${{ matrix.env.xcode }}+${{ matrix.env.runtime }}
+      - name: "Prepare simulator"
+        id: prepare-simulator
+        uses: ./.github/actions/prepare-simulator
+        with:
+          runtime: ${{ matrix.env.runtime }}
+          device: ${{ matrix.env.device }}
+      - name: "Build"
+        run: |
+          set -o pipefail
+          xcodebuild build -workspace "OneTimePassword.xcworkspace" -scheme "OneTimePassword (watchOS)" -destination "id=${{ steps.prepare-simulator.outputs.destination-id }}" | xcpretty -c

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,4 @@
 # Configuration for Hound (https://houndci.com)
 
-swift:
+swiftlint:
   config_file: .swiftlint.yml


### PR DESCRIPTION
- Update GitHub Actions workflow dependencies (https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- Update Hound config to use the local swiftlint config (http://help.houndci.com/en/articles/2138528-swiftlint)