### PR TITLE
Migrate GitHub Actions off of deprecated `set-output` command

### DIFF
--- a/.github/actions/prepare-simulator/action.yml
+++ b/.github/actions/prepare-simulator/action.yml
@@ -51,4 +51,4 @@ runs:
         RUNTIME_ID=com.apple.CoreSimulator.SimRuntime.$(echo $RUNTIME | sed -E -e "s/[ \-]+/ /g" -e "s/[^[:alnum:]]/-/g")
         DESTINATION_ID=$(xcrun simctl create "Custom: $DEVICE, $RUNTIME" $DEVICE_ID $RUNTIME_ID)
         xcrun simctl boot $DESTINATION_ID
-        echo "::set-output name=destination-id::$(echo $DESTINATION_ID)"
+        echo "destination-id=$(echo $DESTINATION_ID)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/